### PR TITLE
Disable custom override of taunt_kill.nut

### DIFF
--- a/mega_mod/mapmods/workshop/tf2ware/minigames/taunt_kill_example.nut
+++ b/mega_mod/mapmods/workshop/tf2ware/minigames/taunt_kill_example.nut
@@ -1,4 +1,6 @@
-// TODO: Remove this file if my pr gets accepted into main tf2ware when I make it -kiwi
+// We did it Grommit! We saved the cheese!
+// Renamed to _example after https://github.com/ficool2/TF2Ware_Ultimate/pull/182 was merged, since it isn't needed anymore, but serves
+// as a good example for how overriding values in minigames could go.
 
 IncludeScript("tf2ware_ultimate/minigames/taunt_kill.nut")
 


### PR DESCRIPTION
If  the pr ficool2/TF2Ware_Ultimate#182 is merged, it renders this code obsolete, so rename the file to
A. keep the folder structure intact
B. have an example of how to override minigames for further reference