### PR TITLE
PLR: Refactor RED/BLU functions into unified architecture

### DIFF
--- a/mega_mod/common/plr_overtime.nut
+++ b/mega_mod/common/plr_overtime.nut
@@ -1,85 +1,107 @@
-// REQUIRED GLOBAL VARIABLES
+// PLR Overtime System - Team-Agnostic Architecture
 // This file should be included at the very start of the map-specific file.
-// InitGlobalVars() MUST be called in OnGameEvent_teamplay_round_start() before any other code.
-// Global variables which differ from these defaults or are set to null must be defined in OnGameEvent_teamplay_round_start().
+// PLR_InitTeams() MUST be called in OnGameEvent_teamplay_round_start() before any other code.
+//
+// Team state is stored in PLR_TEAMS, indexed by TF2 team number (2=RED, 3=BLU, etc.)
+// For 4-team maps, register teams 4 and 5 as well.
+
+// ============================================================================
+// CORE DATA STRUCTURE
+// ============================================================================
+
+::PLR_TEAMS <- {}  // team_num => state table
+::PLR_UPDATE_DEPTH <- 0
+::PLR_NEXT_CROSSING_ID <- 1
+const PLR_MAX_UPDATE_DEPTH = 8  // N teams + safety margin
+
+function PLR_RegisterTeam(team, config) {
+    local rollbackSpeed = -1.0;
+    local speed1 = 0.55;
+    local speed2 = 0.77;
+    local speed3 = 1.0;
+    local overtimeSpeed = 0.22;
+
+    if (config) {
+        if ("rollbackSpeed" in config) rollbackSpeed = config.rollbackSpeed;
+        if ("speed1" in config) speed1 = config.speed1;
+        if ("speed2" in config) speed2 = config.speed2;
+        if ("speed3" in config) speed3 = config.speed3;
+        if ("overtimeSpeed" in config) overtimeSpeed = config.overtimeSpeed;
+    }
+
+    PLR_TEAMS[team] <- {
+        cartsparks = null,
+        flashinglight = null,
+        pushzone = null,
+        logiccase = null,
+        train = null,
+        watcher = null,
+        rollstate = 0,
+        pushstate = 0,
+        blocked = false,
+        crossing = 0,
+        lastUpdate = Time(),
+        rollbackSpeed = rollbackSpeed,
+        speed1 = speed1,
+        speed2 = speed2,
+        speed3 = speed3,
+        overtimeSpeed = overtimeSpeed,
+        custom = {}
+    };
+}
+
+function PLR_GetTeam(team) {
+    if (!(team in PLR_TEAMS)) return null;
+    return PLR_TEAMS[team];
+}
+
+function PLR_GetTeamCount() {
+    local count = 0;
+    foreach (team, state in PLR_TEAMS) count++;
+    return count;
+}
+
+function PLR_ForEachTeam(callback) {
+    foreach (team, state in PLR_TEAMS) {
+        callback(team, state);
+    }
+}
+
+function PLR_CountPushingEnemies(team) {
+    local count = 0;
+    foreach (other, state in PLR_TEAMS) {
+        if (other != team && state.pushstate >= 1) count++;
+    }
+    return count;
+}
+
+// ============================================================================
+// INITIALIZATION
+// ============================================================================
 
 function InitGlobalVars() {
+    PLR_InitStandardTeams();
+    PLR_InitTeams();
+}
 
-    // team_round_timer
+function PLR_InitStandardTeams() {
+    ::PLR_TEAMS <- {};
+    PLR_RegisterTeam(2, {});  // RED
+    PLR_RegisterTeam(3, {});  // BLU
+}
+
+// For 4-team maps, call this after PLR_InitStandardTeams():
+// PLR_RegisterTeam(4, {});  // GREEN
+// PLR_RegisterTeam(5, {});  // YELLOW
+
+function PLR_InitTeams() {
     ::PLR_TIMER <- null;
     ::PLR_TIMER_NAME <- null;
-
-    // Array of all env_spark handles for each cart.
-    ::RED_CARTSPARKS_ARRAY <- null;
-    ::BLU_CARTSPARKS_ARRAY <- null;
-
-    // info_particle_system for the cart's light
-    ::RED_FLASHINGLIGHT <- null;
-    ::BLU_FLASHINGLIGHT <- null;
-
-    // trigger_capture_area for the cart
-    ::RED_PUSHZONE <- null;
-    ::BLU_PUSHZONE <- null;
-
-    // logic_case which accepts OnNumCappersChanged2 inputs
-    ::RED_LOGICCASE <- null;
-    ::BLU_LOGICCASE <- null;
-
-    // 0 if on flat ground, -1 if rolling back, 1 if rolling forward
-    ::RED_ROLLSTATE <- 0;
-    ::BLU_ROLLSTATE <- 0;
-
-    // team_train_watcher for each team
-    ::RED_WATCHER <- null;
-    ::BLU_WATCHER <- null;
-
-    // func_tracktrain for the cart itself
-    ::RED_TRAIN <- null;
-    ::BLU_TRAIN <- null;
-
-    // Number of players on the cart, as decided by the logic_case (does not correspond to case numbers within the logic_case)
-    // -1 means cart is blocked, anything >= 0 means the number of cappers.
-    ::CASE_RED <- 0
-    ::CASE_BLU <- 0
-
-    // Is the cart being controlled by something else? (e.g. is it being guided through a crossing?)
-    ::BLOCK_RED <- false;
-    ::BLOCK_BLU <- false;
-
-    // Which crossing is the cart currently at?
-    // Crossings should be numbered by the order they're encountered for the BLU cart, starting at 1.
-    // 0 means the cart hasn't encountered a crossing.
-    // >0 means the cart has reached/is going through a crossing.
-    // <0 means the cart has completely passed through said crossing. It will keep this value until another crossing is reached.
-    ::CROSSING_RED <- 0;
-    ::CROSSING_BLU <- 0;
-
-    // When was the cart's speed last updated?
-    ::RED_LAST_UPDATE <- Time();
-    ::BLU_LAST_UPDATE <- Time();
-
-    ::ROLLBACK_SPEED_RED <- -1.0;
-    ::TIMES_1_SPEED_RED <- 0.55;
-    ::TIMES_2_SPEED_RED <- 0.77;
-    ::TIMES_3_SPEED_RED <- 1.0;
-
-    ::ROLLBACK_SPEED_BLU <- -1.0;
-    ::TIMES_1_SPEED_BLU <- 0.55;
-    ::TIMES_2_SPEED_BLU <- 0.77;
-    ::TIMES_3_SPEED_BLU <- 1.0;
-
-    ::OVERTIME_SPEED_RED <- 0.22;
-    ::OVERTIME_SPEED_BLU <- 0.22;
-
     ::OVERTIME_ACTIVE <- false;
     ::ROLLBACK_DISABLED <- false;
-
     ::MM_PLR_TIME_UPPER_LIMIT <- 1800;
     ::MM_PLR_TIME_LOWER_LIMIT <- 180;
-
-    // Defines minimum multiplier applied to cart speed for the dynamic speed system.
     ::MM_PLR_MINIMUM_SPEED_RATIO <- 0.35;
-    // Defines distances between the carts as a fraction of track length for the dynamic speed system.
     ::MM_PLR_MINIMUM_DELTA_RATIO <- 0.25;
     ::MM_PLR_MAXIMUM_DELTA_RATIO <- 0.65;
 
@@ -91,35 +113,207 @@ function InitGlobalVars() {
 
 InitGlobalVars();
 
-function OnGameEvent_teamplay_round_win(params) {
-    if (params.team == 2) { // Red team
-        WinRed();
-    } else if (params.team == 3) { // Blu team
-        WinBlu();
-    } else { // Stalemate. Can happen in halloween or if mp_timelimit is reached
-        ForceStopCarts();
+// ============================================================================
+// TEAM-AGNOSTIC CORE FUNCTIONS
+// ============================================================================
+
+function PLR_Advance(team, baseSpeed, dynamic = true) {
+    local t = PLR_GetTeam(team);
+    if (dynamic) baseSpeed = PLR_CalculateDynamicSpeed(baseSpeed, team);
+
+    foreach (spark in t.cartsparks) {
+        EntFireByHandle(spark, "StopSpark", "", 0, null, null);
     }
+    if (t.flashinglight) EntFireByHandle(t.flashinglight, "Start", "", 0, null, null);
+    EntFireByHandle(t.train, "SetSpeedDirAccel", "" + baseSpeed, 0, null, null);
+
+    t.lastUpdate = Time();
 }
 
-function GetRoundTimeString(setup = 0) {
-    return "" + GetRoundTime(setup);
+function PLR_Stop(team) {
+    local t = PLR_GetTeam(team);
+
+    foreach (spark in t.cartsparks) {
+        EntFireByHandle(spark, "StopSpark", "", 0, null, null);
+    }
+    if (t.flashinglight) EntFireByHandle(t.flashinglight, "Stop", "", 0, null, null);
+    EntFireByHandle(t.train, "SetSpeedDirAccel", "0.0", 0, null, null);
+
+    local currentSpeed = NetProps.GetPropFloat(t.train, "m_flSpeed");
+    if (currentSpeed == 0) EntFireByHandle(t.train, "Stop", "", 0, null, null);
+
+    t.lastUpdate = Time();
 }
 
-function GetRoundTime(setup = 0) {
-    local time = MM_PLR_TIME_UPPER_LIMIT;
-    local timeRemaining = MM_GetTimelimitRemaining()
-    if (timeRemaining != null) time = ceil(timeRemaining / 30) * 30;
+function PLR_TriggerRollback(team, multiplier = 1.0) {
+    local t = PLR_GetTeam(team);
 
-    if (time > MM_PLR_TIME_UPPER_LIMIT) time = MM_PLR_TIME_UPPER_LIMIT;
-    if (time < MM_PLR_TIME_LOWER_LIMIT) time = MM_PLR_TIME_LOWER_LIMIT;
+    foreach (spark in t.cartsparks) {
+        EntFireByHandle(spark, "StartSpark", "", 0, null, null);
+    }
+    if (t.flashinglight) EntFireByHandle(t.flashinglight, "Stop", "", 0, null, null);
+    EntFireByHandle(t.train, "SetSpeedDirAccel", "" + (t.rollbackSpeed * multiplier), 0, null, null);
 
-    return time;
+    t.lastUpdate = Time();
 }
 
-// We use a logic case to capture the value obtained from OnNumCappersChanged2
-// name: targetname of logic_case
-// team: "Red" or "Blu"
-function CreateLogicCase(name, team) {
+// ============================================================================
+// UPDATE CART - MAIN STATE MACHINE
+// ============================================================================
+
+function PLR_UpdateCart(team, pushstate) {
+    if (++PLR_UPDATE_DEPTH > PLR_MAX_UPDATE_DEPTH) {
+        --PLR_UPDATE_DEPTH;
+        return;  // Safety abort - prevent infinite loops
+    }
+
+    local t = PLR_GetTeam(team);
+    local previousPushstate = t.pushstate;
+    t.pushstate = pushstate;
+    local N = PLR_GetTeamCount();
+
+    // Early exit if blocked
+    if (t.blocked) {
+        --PLR_UPDATE_DEPTH;
+        return;
+    }
+
+    // Phase 1: Pusher count
+    if (pushstate == -1) {
+        PLR_Stop(team);
+        --PLR_UPDATE_DEPTH;
+        return;
+    }
+
+    if (pushstate == 1) {
+        PLR_Advance(team, t.speed1);
+    } else if (pushstate == 2) {
+        PLR_Advance(team, t.speed2);
+    } else if (pushstate >= 3) {
+        PLR_Advance(team, t.speed3);
+    }
+
+    // Phase 2: Zero pushers
+    if (pushstate == 0) {
+        if (OVERTIME_ACTIVE) {
+            local k = PLR_CountPushingEnemies(team);
+
+            // Calculate pressure-based multipliers
+            local crawlMult = 0;
+            if (k >= N - 1) {
+                crawlMult = 0;  // Special case: full stop
+            } else {
+                crawlMult = 1.0 / (k + 1);
+            }
+
+            if (t.rollstate == -1 && !(OVERTIME_ACTIVE && ROLLBACK_DISABLED)) {
+                // On uphill - decide between crawl and rollback based on pressure
+                if (k >= N - 1) {
+                    // All enemies pushing - full rollback
+                    PLR_TriggerRollback(team, 1.0);
+                } else if (k > 0) {
+                    // Some enemies pushing - rollback at reduced speed
+                    local rollbackMult = 1.0 / (N - k);
+                    PLR_TriggerRollback(team, rollbackMult);
+                } else {
+                    // No enemies pushing - crawl
+                    PLR_Advance(team, t.overtimeSpeed * crawlMult);
+                }
+            } else {
+                // Flat ground or rollback disabled
+                if (crawlMult > 0) {
+                    PLR_Advance(team, t.overtimeSpeed * crawlMult);
+                } else {
+                    PLR_Stop(team);
+                }
+            }
+        } else if (t.rollstate == -1 && !ROLLBACK_DISABLED) {
+            PLR_TriggerRollback(team, 1.0);
+        } else {
+            PLR_Stop(team);
+        }
+    }
+
+    // Phase 3: Overtime cascade
+    if (OVERTIME_ACTIVE && pushstate >= 1) {
+        // I just started pushing - reevaluate idle teams
+        PLR_ForEachTeam(function(other, otherState) {
+            if (other != team && otherState.pushstate == 0) {
+                PLR_UpdateCart(other, 0);
+            }
+        });
+    } else if (OVERTIME_ACTIVE && pushstate == 0 && previousPushstate >= 1) {
+        // I just stopped pushing - check if all are now idle
+        local allIdle = true;
+        foreach (other, otherState in PLR_TEAMS) {
+            if (other != team && otherState.pushstate >= 1) {
+                allIdle = false;
+                break;
+            }
+        }
+        if (allIdle) {
+            // Everyone idle during overtime - all crawl at full speed
+            PLR_ForEachTeam(function(t2, s) {
+                if (!s.blocked) {
+                    PLR_Advance(t2, s.overtimeSpeed);
+                }
+            });
+        }
+    }
+
+    --PLR_UPDATE_DEPTH;
+}
+
+// ============================================================================
+// DYNAMIC SPEED CALCULATION
+// ============================================================================
+
+function PLR_CalculateDynamicSpeed(baseSpeed, teamNum) {
+    local t = PLR_GetTeam(teamNum);
+    local myProgress = NetProps.GetPropFloat(t.watcher, "m_flTotalProgress");
+
+    // For 2-team: compare against the other team
+    if (PLR_GetTeamCount() == 2) {
+        local otherTeam = teamNum == 2 ? 3 : 2;
+        local otherState = PLR_GetTeam(otherTeam);
+        local otherProgress = NetProps.GetPropFloat(otherState.watcher, "m_flTotalProgress");
+
+        // If this cart is behind, don't slow down
+        if (teamNum == 3 && myProgress < otherProgress) return baseSpeed;
+        if (teamNum == 2 && myProgress > otherProgress) return baseSpeed;
+
+        local distance = fabs(myProgress - otherProgress);
+
+        if (distance < MM_PLR_MINIMUM_DELTA_RATIO) return baseSpeed;
+        else if (distance > MM_PLR_MAXIMUM_DELTA_RATIO) return baseSpeed * MM_PLR_MINIMUM_SPEED_RATIO;
+
+        local scaledDistance = (distance - MM_PLR_MINIMUM_DELTA_RATIO) / (MM_PLR_MAXIMUM_DELTA_RATIO - MM_PLR_MINIMUM_DELTA_RATIO);
+        local speedRatio = 1 - scaledDistance * (1 - MM_PLR_MINIMUM_SPEED_RATIO);
+        return baseSpeed * speedRatio;
+    }
+
+    // For 4-team: compare against the closest competitor
+    local closestDistance = 1.0;
+    foreach (other, otherState in PLR_TEAMS) {
+        if (other == teamNum) continue;
+        local otherProgress = NetProps.GetPropFloat(otherState.watcher, "m_flTotalProgress");
+        local distance = fabs(myProgress - otherProgress);
+        if (distance < closestDistance) closestDistance = distance;
+    }
+
+    if (closestDistance < MM_PLR_MINIMUM_DELTA_RATIO) return baseSpeed;
+    else if (closestDistance > MM_PLR_MAXIMUM_DELTA_RATIO) return baseSpeed * MM_PLR_MINIMUM_SPEED_RATIO;
+
+    local scaledDistance = (closestDistance - MM_PLR_MINIMUM_DELTA_RATIO) / (MM_PLR_MAXIMUM_DELTA_RATIO - MM_PLR_MINIMUM_DELTA_RATIO);
+    local speedRatio = 1 - scaledDistance * (1 - MM_PLR_MINIMUM_SPEED_RATIO);
+    return baseSpeed * speedRatio;
+}
+
+// ============================================================================
+// SETUP HELPERS
+// ============================================================================
+
+function PLR_CreateLogicCase(team, name) {
     local logicCase = SpawnEntityFromTable("logic_case", {
         targetname = name,
         Case01 = "-1",
@@ -127,350 +321,236 @@ function CreateLogicCase(name, team) {
         Case03 = "1",
         Case04 = "2"
     });
-    AddCaptureOutputsToLogicCase(logicCase, team);
+    PLR_AddCaptureOutputsToLogicCase(team, logicCase);
     return logicCase;
 }
 
-// entity: handle of logic_case
-// team: "Red" or "Blu"
-function AddCaptureOutputsToLogicCase(entity, team) {
-    EntityOutputs.AddOutput(entity, "OnCase01", "!self", "RunScriptCode", "Update" + team + "Cart(-1)", 0, -1); // Blocked
-    EntityOutputs.AddOutput(entity, "OnCase02", "!self", "RunScriptCode", "Update" + team + "Cart(0)", 0, -1); // 0 cap
-    EntityOutputs.AddOutput(entity, "OnCase03", "!self", "RunScriptCode", "Update" + team + "Cart(1)", 0, -1); // 1 cap
-    EntityOutputs.AddOutput(entity, "OnCase04", "!self", "RunScriptCode", "Update" + team + "Cart(2)", 0, -1); // 2 cap
-    EntityOutputs.AddOutput(entity, "OnDefault", "!self", "RunScriptCode", "Update" + team + "Cart(3)", 0, -1); // 3+ cap
+function PLR_AddCaptureOutputsToLogicCase(team, entity) {
+    EntityOutputs.AddOutput(entity, "OnCase01", "!self", "RunScriptCode",
+        "PLR_UpdateCart(" + team + ", -1)", 0, -1);
+    EntityOutputs.AddOutput(entity, "OnCase02", "!self", "RunScriptCode",
+        "PLR_UpdateCart(" + team + ", 0)", 0, -1);
+    EntityOutputs.AddOutput(entity, "OnCase03", "!self", "RunScriptCode",
+        "PLR_UpdateCart(" + team + ", 1)", 0, -1);
+    EntityOutputs.AddOutput(entity, "OnCase04", "!self", "RunScriptCode",
+        "PLR_UpdateCart(" + team + ", 2)", 0, -1);
+    EntityOutputs.AddOutput(entity, "OnDefault", "!self", "RunScriptCode",
+        "PLR_UpdateCart(" + team + ", 3)", 0, -1);
 }
 
-function StartOvertime() {
-    ::OVERTIME_ACTIVE <- true;
+function PLR_AddRollbackZone(team, startPath, endPath, disablePath) {
+    local t = PLR_GetTeam(team);
+    local sparksName = t.cartsparks[0].GetName();
 
-    if(PLR_TIMER && PLR_TIMER.IsValid()) PLR_TIMER.Kill();
-
-    UpdateRedCart(CASE_RED);
-    UpdateBluCart(CASE_BLU);
-}
-
-// These functions determine the cart behaviour depending on number of pushing players.
-
-function UpdateRedCart(caseNumber) {
-    ::CASE_RED = caseNumber;
-
-    if(BLOCK_RED) return;
-
-    if(CASE_RED == 1) {
-        AdvanceRed(TIMES_1_SPEED_RED);
-    } else if(CASE_RED == 2) {
-        AdvanceRed(TIMES_2_SPEED_RED);
-    } else if(CASE_RED >= 3) {
-        AdvanceRed(TIMES_3_SPEED_RED);
-    } else if (CASE_RED == -1) {
-        StopRed();
+    EntityOutputs.AddOutput(MM_GetEntByName(startPath), "OnPass", sparksName,
+        "StopSpark", "", 0, -1);
+    EntityOutputs.AddOutput(MM_GetEntByName(startPath), "OnPass", disablePath,
+        "DisablePath", "", 0, -1);
+    EntityOutputs.AddOutput(MM_GetEntByName(startPath), "OnPass", "!self",
+        "RunScriptCode", "PLR_RollbackStart(" + team + ")", 0, -1);
+    if (endPath) {
+        EntityOutputs.AddOutput(MM_GetEntByName(endPath), "OnPass", "!self",
+            "RunScriptCode", "PLR_RollbackEnd(" + team + ")", 0, -1);
     }
+}
 
-    if(CASE_RED == 0) {
-        if(CASE_BLU == 0 && OVERTIME_ACTIVE) {
-            AdvanceRed(OVERTIME_SPEED_RED);
-            if(!BLOCK_BLU) AdvanceBlu(OVERTIME_SPEED_BLU);
-        } else if (!(OVERTIME_ACTIVE && ROLLBACK_DISABLED) && RED_ROLLSTATE == -1) {
-            TriggerRollbackRed();
-        } else {
-            StopRed();
+function PLR_AddRollforwardZone(team, startPath, endPath, disablePath) {
+    EntityOutputs.AddOutput(MM_GetEntByName(startPath), "OnPass", "!self",
+        "RunScriptCode", "PLR_RollforwardStart(" + team + ")", 0, -1);
+    if (endPath) {
+        EntityOutputs.AddOutput(MM_GetEntByName(endPath), "OnPass", "!self",
+            "RunScriptCode", "PLR_RollforwardEnd(" + team + ")", 0, -1);
+        EntityOutputs.AddOutput(MM_GetEntByName(endPath), "OnPass", disablePath,
+            "DisablePath", "", 0, -1);
+    }
+}
+
+// AddCrossing: Register one or more teams on a shared crossing.
+// teams: Array of [startPath, endPath, team] triplets.
+// The crossing ID is auto-generated.
+// Example: AddCrossing([["red_start", "red_end", 2], ["blu_start", "blu_end", 3]])
+function AddCrossing(teams) {
+    local crossingID = PLR_NEXT_CROSSING_ID++;
+    if (teams.len() < 2) {
+        throw "AddCrossing requires at least 2 teams";
+    }
+    local registeredTeams = {};
+    for (local i = 0; i < teams.len(); i++) {
+        local group = teams[i];
+        if (group.len() != 3) {
+            throw "AddCrossing team group must have exactly 3 elements: [startPath, endPath, team]";
         }
-    } else if (OVERTIME_ACTIVE && CASE_BLU == 0) {
-        UpdateBluCart(0);
-    }
-}
-
-function UpdateBluCart(caseNumber) {
-    ::CASE_BLU = caseNumber;
-
-    if(BLOCK_BLU) return;
-
-    if(CASE_BLU == 1) {
-        AdvanceBlu(TIMES_1_SPEED_BLU);
-    } else if(CASE_BLU == 2) {
-        AdvanceBlu(TIMES_2_SPEED_BLU);
-    } else if(CASE_BLU >= 3) {
-        AdvanceBlu(TIMES_3_SPEED_BLU);
-    } else if (CASE_BLU == -1) {
-        StopBlu();
-    }
-
-    if(CASE_BLU == 0) {
-        if(CASE_RED == 0 && OVERTIME_ACTIVE) {
-            AdvanceBlu(OVERTIME_SPEED_BLU);
-            if(!BLOCK_RED) AdvanceRed(OVERTIME_SPEED_RED);
-        } else if (!(OVERTIME_ACTIVE && ROLLBACK_DISABLED) && BLU_ROLLSTATE == -1) {
-            TriggerRollbackBlu();
-        } else {
-            StopBlu();
+        local startPath = group[0];
+        local endPath = group[1];
+        local team = group[2];
+        if (team in registeredTeams) {
+            throw "AddCrossing: Team " + team + " registered twice on crossing " + crossingID;
         }
-    } else if (OVERTIME_ACTIVE && CASE_RED == 0) {
-        UpdateRedCart(0);
+        registeredTeams[team] = true;
+        EntityOutputs.AddOutput(MM_GetEntByName(startPath), "OnPass", "!self",
+            "RunScriptCode", "PLR_SetCrossing(" + team + ", " + crossingID + ")", 0, -1);
+        EntityOutputs.AddOutput(MM_GetEntByName(endPath), "OnPass", "!self",
+            "RunScriptCode", "PLR_SetCrossing(" + team + ", 0)", 0, -1);
     }
 }
 
-// Called by other code to directly control the cart.
 
-function AdvanceRed(speed, dynamic = true) {
-
-    if (dynamic) speed = CalculateDynamicSpeed(speed, 2);
-
-    foreach(spark in RED_CARTSPARKS_ARRAY) {
-        EntFireByHandle(spark, "StopSpark", "", 0, null, null);
-    }
-    if(RED_FLASHINGLIGHT) EntFireByHandle(RED_FLASHINGLIGHT, "Start", "", 0, null, null);
-    EntFireByHandle(RED_TRAIN, "SetSpeedDirAccel", "" + speed, 0, null, null);
-
-    ::RED_LAST_UPDATE <- Time();
-}
-
-function StopRed() {
-    foreach(spark in RED_CARTSPARKS_ARRAY) {
-        EntFireByHandle(spark, "StopSpark", "", 0, null, null);
-    }
-    if(RED_FLASHINGLIGHT) EntFireByHandle(RED_FLASHINGLIGHT, "Stop", "", 0, null, null);
-    EntFireByHandle(RED_TRAIN, "SetSpeedDirAccel", "0.0", 0, null, null);
-
-    // Stop sound if cart is completely stopped.
-    local currentSpeed = NetProps.GetPropFloat(RED_TRAIN, "m_flSpeed");
-    if (currentSpeed == 0) EntFireByHandle(RED_TRAIN, "Stop", "", 0, null, null);
-
-    ::RED_LAST_UPDATE <- Time();
-}
-
-function TriggerRollbackRed() {
-    foreach(spark in RED_CARTSPARKS_ARRAY) {
-        EntFireByHandle(spark, "StartSpark", "", 0, null, null);
-    }
-    if(RED_FLASHINGLIGHT) EntFireByHandle(RED_FLASHINGLIGHT, "Stop", "", 0, null, null);
-    EntFireByHandle(RED_TRAIN, "SetSpeedDirAccel", "" + ROLLBACK_SPEED_RED, 0, null, null);
-
-    ::RED_LAST_UPDATE <- Time();
-}
-
-function AdvanceBlu(speed, dynamic = true) {
-
-    if (dynamic) speed = CalculateDynamicSpeed(speed, 3);
-
-    foreach(spark in BLU_CARTSPARKS_ARRAY) {
-        EntFireByHandle(spark, "StopSpark", "", 0, null, null);
-    }
-    if(BLU_FLASHINGLIGHT) EntFireByHandle(BLU_FLASHINGLIGHT, "Start", "", 0, null, null);
-    EntFireByHandle(BLU_TRAIN, "SetSpeedDirAccel", "" + speed, 0, null, null);
-
-    ::BLU_LAST_UPDATE <- Time();
-}
-
-function StopBlu() {
-    foreach(spark in BLU_CARTSPARKS_ARRAY) {
-        EntFireByHandle(spark, "StopSpark", "", 0, null, null);
-    }
-    if(BLU_FLASHINGLIGHT) EntFireByHandle(BLU_FLASHINGLIGHT, "Stop", "", 0, null, null);
-    EntFireByHandle(BLU_TRAIN, "SetSpeedDirAccel", "0.0", 0, null, null);
-
-    // Stop sound if cart is completely stopped.
-    local currentSpeed = NetProps.GetPropFloat(BLU_TRAIN, "m_flSpeed");
-    if (currentSpeed == 0) EntFireByHandle(BLU_TRAIN, "Stop", "", 0, null, null);
-
-    ::BLU_LAST_UPDATE <- Time();
-}
-
-function TriggerRollbackBlu() {
-    foreach(spark in BLU_CARTSPARKS_ARRAY) {
-        EntFireByHandle(spark, "StartSpark", "", 0, null, null);
-    }
-    if(BLU_FLASHINGLIGHT) EntFireByHandle(BLU_FLASHINGLIGHT, "Stop", "", 0, null, null);
-    EntFireByHandle(BLU_TRAIN, "SetSpeedDirAccel", "" + ROLLBACK_SPEED_BLU, 0, null, null);
-
-    ::BLU_LAST_UPDATE <- Time();
-}
-
-// Called by path_track as the cart enters and exits rollback/rollforward zones
-
-function RollbackStartRed() {
-    ::RED_ROLLSTATE <- -1;
-}
-
-function RollbackEndRed() {
-    ::RED_ROLLSTATE <- 0;
-}
-
-function RollforwardStartRed() {
-    ::RED_ROLLSTATE <- 1;
-    RED_PUSHZONE.AcceptInput("Disable", "", null, null);
-    BlockRedCart(true);
-    AdvanceRed(1, false);
-}
-
-function RollforwardEndRed() {
-    ::RED_ROLLSTATE <- 0;
-    BlockRedCart(false);
-    RED_PUSHZONE.AcceptInput("Enable", "", null, null);
-}
-
-function RollbackStartBlu() {
-    ::BLU_ROLLSTATE <- -1;
-}
-
-function RollbackEndBlu() {
-    ::BLU_ROLLSTATE <- 0;
-}
-
-function RollforwardStartBlu() {
-    ::BLU_ROLLSTATE <- 1;
-    BLU_PUSHZONE.AcceptInput("Disable", "", null, null);
-    BlockBluCart(true);
-    AdvanceBlu(1, false);
-}
-
-function RollforwardEndBlu() {
-    ::BLU_ROLLSTATE <- 0;
-    BlockBluCart(false);
-    BLU_PUSHZONE.AcceptInput("Enable", "", null, null);
-}
-
-// This is for situations where the game takes control of the cart, like onboarding the cart to the Hightower elevators.
-// Don't use these functions to handle crossings; use SetRedCrossing/SetBluCrossing instead.
-
-function BlockRedCart(blocked) {
-    ::BLOCK_RED <- blocked;
-    UpdateRedCart(CASE_RED);
-    UpdateBluCart(CASE_BLU);
-}
-
-function BlockBluCart(blocked) {
-    ::BLOCK_BLU <- blocked;
-    UpdateBluCart(CASE_BLU);
-    UpdateRedCart(CASE_RED);
-}
-
-// This function is called by the AdvanceRed/AdvanceBlu functions to determine the speed of the cart.
-// Dynamic speed forces the leading cart to slow down if it's too far ahead of the other team's cart.
-
-function CalculateDynamicSpeed(baseSpeed, teamNum) {
-    // Get the positions of the carts (they are ratios between 0.0 and 1.0)
-    local redPos = NetProps.GetPropFloat(RED_WATCHER, "m_flTotalProgress");
-    local bluPos = NetProps.GetPropFloat(BLU_WATCHER, "m_flTotalProgress");
-
-    // If this cart is behind, don't do anything.
-    if (redPos > bluPos && teamNum == 3) return baseSpeed;
-    if (bluPos > redPos && teamNum == 2) return baseSpeed;
-
-    local distance = fabs(redPos - bluPos);
-
-    if (distance < MM_PLR_MINIMUM_DELTA_RATIO) return baseSpeed;
-    else if (distance > MM_PLR_MAXIMUM_DELTA_RATIO) return baseSpeed * MM_PLR_MINIMUM_SPEED_RATIO;
-
-    local scaledDistance = (distance - MM_PLR_MINIMUM_DELTA_RATIO) / (MM_PLR_MAXIMUM_DELTA_RATIO - MM_PLR_MINIMUM_DELTA_RATIO);
-
-    // Calculate the speed ratio based on the distance between the carts.
-    local speedRatio = 1 - scaledDistance * (1 - MM_PLR_MINIMUM_SPEED_RATIO);
-    return baseSpeed * speedRatio;
-}
-
-// This function creates a think for the cart entity which periodically updates the cart speed.
-// team: "Red" or "Blu"
-function CreateCartAutoUpdater(cart, team)
-{
-    if (team != 2 && team != 3) return;
-
-    local thinkName = team == 2 ? "CartThinkRed" : "CartThinkBlu";
-
+function PLR_CreateCartAutoUpdater(team, cart) {
+    local thinkName = "PLR_CartThink_" + team;
+    local capturedTeam = team;
+    local root = getroottable();
+    root[thinkName] <- function() { return PLR_CartThink(capturedTeam); };
     AddThinkToEnt(cart, thinkName);
 }
 
-function CartThinkRed() {
-    return CartThink(2);
-}
+// ============================================================================
+// CROSSING LOGIC
+// ============================================================================
 
-function CartThinkBlu() {
-    return CartThink(3);
-}
+function PLR_SetCrossing(team, crossingID) {
+    local t = PLR_GetTeam(team);
 
-function CartThink(team) {
-    local updateInterval = 2.5;
-    local cart = team == 2 ? RED_TRAIN : BLU_TRAIN;
-    local lastUpdate = team == 2 ? RED_LAST_UPDATE : BLU_LAST_UPDATE;
-    local rollstate = team == 2 ? RED_ROLLSTATE : BLU_ROLLSTATE;
-    if (Time() - lastUpdate > updateInterval && rollstate == 0) {
-        // Update the cart's state (and therefore speed).
-        lastUpdate = Time();
-        if (team == 2) {
-            UpdateRedCart(CASE_RED);
-            ::RED_LAST_UPDATE <- lastUpdate;
+    if (crossingID == 0) {
+        // Exited a crossing - unblock this team
+        t.crossing = 0;
+        t.pushzone.AcceptInput("Enable", "", null, null);
+        PLR_BlockCart(team, false);
+
+        // Wake up any other team waiting on the same crossing
+        PLR_ForEachTeam(function(other, otherState) {
+            if (other != team && otherState.crossing == t._waitingCrossing) {
+                // The crossing is now free - let the waiting team proceed slowly
+                otherState._waitingCrossing = 0;
+                otherState.pushzone.AcceptInput("Enable", "", null, null);
+                PLR_BlockCart(other, false);
+                EntFireByHandle(otherState.train, "RunScriptCode",
+                    "PLR_Advance(" + other + ", " + otherState.speed1 + ", false)", 0.5, null, null);
+            }
+        });
+    } else {
+        // Entering a crossing
+        local conflict = false;
+        local waitingTeam = null;
+
+        // Check if any other team is already in this crossing
+        PLR_ForEachTeam(function(other, otherState) {
+            if (other != team && otherState.crossing == crossingID) {
+                conflict = true;
+                waitingTeam = other;
+            }
+        });
+
+        if (conflict) {
+            // Another team is in this crossing - stop and wait
+            t.crossing = crossingID;
+            t._waitingCrossing <- crossingID;
+            t.pushzone.AcceptInput("Disable", "", null, null);
+            PLR_BlockCart(team, true);
+            PLR_Stop(team);
         } else {
-            UpdateBluCart(CASE_BLU);
-            ::BLU_LAST_UPDATE <- lastUpdate;
+            // Crossing is clear - enter it
+            t.crossing = crossingID;
         }
     }
-    local timeUntilNextCheck = updateInterval - (Time() - lastUpdate);
+}
+
+// ============================================================================
+// ROLLBACK/ROLLFORWARD
+// ============================================================================
+
+function PLR_RollbackStart(team) {
+    PLR_TEAMS[team].rollstate = -1;
+}
+
+function PLR_RollbackEnd(team) {
+    PLR_TEAMS[team].rollstate = 0;
+}
+
+function PLR_RollforwardStart(team) {
+    local t = PLR_TEAMS[team];
+    t.rollstate = 1;
+    t.pushzone.AcceptInput("Disable", "", null, null);
+    PLR_BlockCart(team, true);
+    PLR_Advance(team, 1, false);
+}
+
+function PLR_RollforwardEnd(team) {
+    local t = PLR_TEAMS[team];
+    t.rollstate = 0;
+    PLR_BlockCart(team, false);
+    t.pushzone.AcceptInput("Enable", "", null, null);
+}
+
+// ============================================================================
+// BLOCKING
+// ============================================================================
+
+function PLR_BlockCart(team, blocked) {
+    PLR_TEAMS[team].blocked = blocked;
+    PLR_ForEachTeam(function(other, state) {
+        if (other != team) PLR_UpdateCart(other, state.pushstate);
+    });
+    PLR_UpdateCart(team, PLR_TEAMS[team].pushstate);
+}
+
+// ============================================================================
+// CART THINK
+// ============================================================================
+
+function PLR_CartThink(team) {
+    local t = PLR_GetTeam(team);
+    local updateInterval = 2.5;
+    if (Time() - t.lastUpdate > updateInterval && t.rollstate == 0) {
+        t.lastUpdate = Time();
+        PLR_UpdateCart(team, t.pushstate);
+    }
+    local timeUntilNextCheck = updateInterval - (Time() - t.lastUpdate);
     if (timeUntilNextCheck < 0.5) timeUntilNextCheck = 0.5;
     return timeUntilNextCheck;
 }
 
-// These functions set the crossing value, then block the cart from being updated
-// if it's the first cart to reach that crossing.
-// TODO: This logic can't handle rotationally symmetric maps with crossings that the carts reach in different orders. Thankfully none exist yet.
-function SetRedCrossing(crossing) {
-    ::CROSSING_RED <- crossing;
-    // If we exited a crossing.
-    if(CROSSING_RED <= 0) {
-        RED_PUSHZONE.AcceptInput("Enable", "", null, null);
-        BlockRedCart(false);
-        // If the other cart is waiting at the crossing we just exited.
-        if(CROSSING_RED == -CROSSING_BLU) {
-            BLU_PUSHZONE.AcceptInput("Enable", "", null, null);
-            BlockBluCart(false);
-        }
-    // If we entered a crossing and the other cart is going through the same crossing.
-    } else if (CROSSING_RED == CROSSING_BLU) {
-        RED_PUSHZONE.AcceptInput("Disable", "", null, null);
-        BlockRedCart(true);
-        StopRed();
-    // If we entered a crossing and the other cart hasn't reached this crossing yet.
-    } else if (CROSSING_RED > abs(CROSSING_BLU)) {
-        RED_PUSHZONE.AcceptInput("Disable", "", null, null);
-        BlockRedCart(true);
-        EntFireByHandle(RED_TRAIN, "RunScriptCode", "AdvanceRed(TIMES_1_SPEED_RED)", 0.5, null, null);
-    }
-    // Do nothing if we entered a crossing and the other cart has already passed through the crossing.
+// ============================================================================
+// ROUND MANAGEMENT
+// ============================================================================
+
+function StartOvertime() {
+    ::OVERTIME_ACTIVE <- true;
+    if (PLR_TIMER && PLR_TIMER.IsValid()) PLR_TIMER.Kill();
+    PLR_ForEachTeam(function(team, state) {
+        PLR_UpdateCart(team, state.pushstate);
+    });
 }
 
-function SetBluCrossing(crossing) {
-    ::CROSSING_BLU <- crossing;
-    // If we exited a crossing.
-    if(CROSSING_BLU <= 0) {
-        BLU_PUSHZONE.AcceptInput("Enable", "", null, null);
-        BlockBluCart(false);
-        // If the other cart is waiting at the crossing we just exited.
-        if(CROSSING_BLU == -CROSSING_RED) {
-            RED_PUSHZONE.AcceptInput("Enable", "", null, null);
-            BlockRedCart(false);
-        }
-    // If we entered a crossing and the other cart is going through the same crossing.
-    } else if (CROSSING_BLU == CROSSING_RED) {
-        BLU_PUSHZONE.AcceptInput("Disable", "", null, null);
-        BlockBluCart(true);
-        StopBlu();
-    // If we entered a crossing and the other cart hasn't reached this crossing yet.
-    } else if (CROSSING_BLU > abs(CROSSING_RED)) {
-        BLU_PUSHZONE.AcceptInput("Disable", "", null, null);
-        BlockBluCart(true);
-        EntFireByHandle(BLU_TRAIN, "RunScriptCode", "AdvanceBlu(TIMES_1_SPEED_BLU)", 0.5, null, null);
-    }
-    // Do nothing if we entered a crossing and the other cart has already passed through the crossing.
+function ForceStopCarts() {
+    if (PLR_TIMER && PLR_TIMER.IsValid()) PLR_TIMER.Kill();
+    ::OVERTIME_ACTIVE <- false;
+    ::ROLLBACK_DISABLED <- false;
+    PLR_ForEachTeam(function(team, state) {
+        state.blocked = true;
+        PLR_Stop(team);
+    });
 }
 
-// Permanently disables overtime rollback.
-// Used to prevent map breaking in some way e.g. on the hightower lifts.
-// Has no effect if overtime is not active.
+function ResetCartStates() {
+    ::OVERTIME_ACTIVE <- false;
+    ::ROLLBACK_DISABLED <- false;
+    local now = Time();
+    PLR_ForEachTeam(function(team, state) {
+        state.rollstate = 0;
+        state.blocked = false;
+        state.lastUpdate = now;
+    });
+    PLR_ForEachTeam(function(team, state) {
+        PLR_UpdateCart(team, 0);
+    });
+}
+
 function DisableOvertimeRollback() {
-    if(ROLLBACK_DISABLED) return;
+    if (ROLLBACK_DISABLED) return;
     ::ROLLBACK_DISABLED <- true;
-    if(!OVERTIME_ACTIVE) return;
+    if (!OVERTIME_ACTIVE) return;
     AnnounceRollbackDisabled();
-    if(PLR_TIMER && PLR_TIMER.IsValid()) PLR_TIMER.Kill();
+    if (PLR_TIMER && PLR_TIMER.IsValid()) PLR_TIMER.Kill();
 }
 
 function AnnounceRollbackDisabled() {
@@ -484,74 +564,72 @@ function AnnounceRollbackDisabled() {
     EntFireByHandle(text_tf, "Kill", "", 7, self, self);
 }
 
-// The following functions are helpers to convert PLR maps from using team_train_watcher
-// to handling all cart movement with VScript.
+// ============================================================================
+// TIMER HELPERS
+// ============================================================================
 
-// startPath: The first path_track with "Part of an uphill path" checked.
-// endPath: The last path_track with "Part of an uphill path" checked. Use null for the end of the track if it should roll back after reaching it (e.g. banana bay)
-// disablePath: The path_track immediately before startPath that will be disabled when the cart enters the rollback zone.
-// team: "Red" or "Blu"
-function AddRollbackZone(startPath, endPath, disablePath, team) {
-    local cartSparksName = (team == "Red" ? RED_CARTSPARKS_ARRAY : BLU_CARTSPARKS_ARRAY)[0].GetName();
-    EntityOutputs.AddOutput(MM_GetEntByName(startPath), "OnPass", cartSparksName, "StopSpark", "", 0, -1);
-    EntityOutputs.AddOutput(MM_GetEntByName(startPath), "OnPass", disablePath, "DisablePath", "", 0, -1);
-    EntityOutputs.AddOutput(MM_GetEntByName(startPath), "OnPass", "!self", "RunScriptCode", "RollbackStart" + team + "()", 0, -1);
-    if(endPath) EntityOutputs.AddOutput(MM_GetEntByName(endPath), "OnPass", "!self", "RunScriptCode", "RollbackEnd" + team + "()", 0, -1);
+function GetRoundTimeString(setup = 0) {
+    return "" + GetRoundTime(setup);
 }
 
-// startPath: The first path_track with "Part of a downhill path" checked.
-// endPath: The last path_track with "Part of a downhill path" checked.
-// disablePath: The path_track immediately before endPath that will be disabled when the cart leaves the rollforward zone.
-// team: "Red" or "Blu"
-function AddRollforwardZone(startPath, endPath, disablePath, team) {
-    EntityOutputs.AddOutput(MM_GetEntByName(startPath), "OnPass", "!self", "RunScriptCode", "RollforwardStart" + team + "()", 0, -1);
-    if(endPath) EntityOutputs.AddOutput(MM_GetEntByName(endPath), "OnPass", "!self", "RunScriptCode", "RollforwardEnd" + team + "()", 0, -1);
-    if(endPath) EntityOutputs.AddOutput(MM_GetEntByName(endPath), "OnPass", disablePath, "DisablePath", "", 0, -1);
+function GetRoundTime(setup = 0) {
+    local time = MM_PLR_TIME_UPPER_LIMIT;
+    local timeRemaining = MM_GetTimelimitRemaining();
+    if (timeRemaining != null) time = ceil(timeRemaining / 30) * 30;
+    if (time > MM_PLR_TIME_UPPER_LIMIT) time = MM_PLR_TIME_UPPER_LIMIT;
+    if (time < MM_PLR_TIME_LOWER_LIMIT) time = MM_PLR_TIME_LOWER_LIMIT;
+    return time;
 }
 
-function AddCrossing(startPathRed, endPathRed, startPathBlu, endPathBlu, index) {
-    EntityOutputs.AddOutput(MM_GetEntByName(startPathRed), "OnPass", "!self", "RunScriptCode", "SetRedCrossing(" + index + ")", 0, -1);
-    EntityOutputs.AddOutput(MM_GetEntByName(endPathRed), "OnPass", "!self", "RunScriptCode", "SetRedCrossing(" + -index + ")", 0, -1);
-    EntityOutputs.AddOutput(MM_GetEntByName(startPathBlu), "OnPass", "!self", "RunScriptCode", "SetBluCrossing(" + index + ")", 0, -1);
-    EntityOutputs.AddOutput(MM_GetEntByName(endPathBlu), "OnPass", "!self", "RunScriptCode", "SetBluCrossing(" + -index + ")", 0, -1);
+// ============================================================================
+// ROUND WIN
+// ============================================================================
+
+function OnGameEvent_teamplay_round_win(params) {
+    if (params.team == 2) {
+        WinRed();
+    } else if (params.team == 3) {
+        WinBlu();
+    } else {
+        ForceStopCarts();
+    }
 }
 
-// Used to stop the carts at the end of a round.
-// Typically only needed for multistage maps or maps with special endings (e.g. Helltower).
-function ForceStopCarts() {
-    if (PLR_TIMER && PLR_TIMER.IsValid()) PLR_TIMER.Kill();
-
-    ::OVERTIME_ACTIVE <- false;
-    ::ROLLBACK_DISABLED <- false;
-
-    ::BLOCK_RED <- true;
-    ::BLOCK_BLU <- true;
-
-    StopRed();
-    StopBlu();
-}
-
-// Called whenever the cart states need to be reset (usually for multistage maps).
-function ResetCartStates() {
-    ::RED_ROLLSTATE <- 0;
-    ::BLU_ROLLSTATE <- 0;
-    ::BLOCK_RED <- false;
-    ::BLOCK_BLU <- false;
-    ::OVERTIME_ACTIVE <- false;
-    ::ROLLBACK_DISABLED <- false;
-
-    ::RED_LAST_UPDATE <- Time();
-    ::BLU_LAST_UPDATE <- Time();
-
-    UpdateRedCart(0);
-    UpdateBluCart(0);
-}
-
-// Called whenever a team wins the round (includes all stages in multistage maps).
 function WinRed() {
     ForceStopCarts();
 }
 
 function WinBlu() {
     ForceStopCarts();
+}
+
+// ============================================================================
+// LEGACY ALIASES (for entity output strings that use old function names)
+// These use the team string "Red"/"Blu" to determine team number.
+// Map mods should migrate to PLR_* versions.
+// ============================================================================
+
+function CreateLogicCase(name, team) {
+    local t = team == "Red" ? 2 : 3;
+    return PLR_CreateLogicCase(t, name);
+}
+
+function AddCaptureOutputsToLogicCase(entity, team) {
+    local t = team == "Red" ? 2 : 3;
+    PLR_AddCaptureOutputsToLogicCase(t, entity);
+}
+
+function AddRollbackZone(startPath, endPath, disablePath, team) {
+    local t = team == "Red" ? 2 : 3;
+    PLR_AddRollbackZone(t, startPath, endPath, disablePath);
+}
+
+function AddRollforwardZone(startPath, endPath, disablePath, team) {
+    local t = team == "Red" ? 2 : 3;
+    PLR_AddRollforwardZone(t, startPath, endPath, disablePath);
+}
+
+
+function CreateCartAutoUpdater(cart, team) {
+    PLR_CreateCartAutoUpdater(team, cart);
 }

--- a/mega_mod/common/plr_overtime.nut
+++ b/mega_mod/common/plr_overtime.nut
@@ -10,6 +10,7 @@
 // ============================================================================
 
 ::PLR_TEAMS <- {}  // team_num => state table
+::PLR_CROSSINGS <- {}  // crossingID => { teams: [team,...], passed: [], queue: [team,...], disabled: false }
 ::PLR_UPDATE_DEPTH <- 0
 ::PLR_NEXT_CROSSING_ID <- 1
 const PLR_MAX_UPDATE_DEPTH = 8  // N teams + safety margin
@@ -39,7 +40,8 @@ function PLR_RegisterTeam(team, config) {
         rollstate = 0,
         pushstate = 0,
         blocked = false,
-        crossing = 0,
+        currentCrossing = 0,  // Crossing ID this team is currently in (0 = none)
+        waitingAtCrossing = false,  // Is this team waiting for another team to exit a crossing?
         lastUpdate = Time(),
         rollbackSpeed = rollbackSpeed,
         speed1 = speed1,
@@ -86,6 +88,7 @@ function InitGlobalVars() {
 
 function PLR_InitStandardTeams() {
     ::PLR_TEAMS <- {};
+    ::PLR_CROSSINGS <- {};
     PLR_RegisterTeam(2, {});  // RED
     PLR_RegisterTeam(3, {});  // BLU
 }
@@ -374,7 +377,8 @@ function PLR_AddCrossing(teams) {
     if (teams.len() < 2) {
         throw "AddCrossing requires at least 2 teams";
     }
-    local registeredTeams = {};
+    local registeredTeams = [];
+    local crossingTeams = [];
     for (local i = 0; i < teams.len(); i++) {
         local group = teams[i];
         if (group.len() != 3) {
@@ -383,15 +387,17 @@ function PLR_AddCrossing(teams) {
         local startPath = group[0];
         local endPath = group[1];
         local team = group[2];
-        if (team in registeredTeams) {
+        if (registeredTeams.find(team) != null) {
             throw "AddCrossing: Team " + team + " registered twice on crossing " + crossingID;
         }
-        registeredTeams[team] = true;
+        registeredTeams.push(team);
+        crossingTeams.push(team);
         EntityOutputs.AddOutput(MM_GetEntByName(startPath), "OnPass", "!self",
             "RunScriptCode", "PLR_SetCrossing(" + team + ", " + crossingID + ")", 0, -1);
         EntityOutputs.AddOutput(MM_GetEntByName(endPath), "OnPass", "!self",
             "RunScriptCode", "PLR_SetCrossing(" + team + ", 0)", 0, -1);
     }
+    PLR_CROSSINGS[crossingID] <- {"teams" : crossingTeams, "passed" : [], "queue" : [], "disabled" : false};
 }
 
 
@@ -411,45 +417,85 @@ function PLR_SetCrossing(team, crossingID) {
     local t = PLR_GetTeam(team);
 
     if (crossingID == 0) {
-        // Exited a crossing - unblock this team
-        t.crossing = 0;
-        t.pushzone.AcceptInput("Enable", "", null, null);
-        PLR_BlockCart(team, false);
+        // Exited a crossing
+        local exitedCrossing = t.currentCrossing;
+        if (exitedCrossing == 0) {
+            throw "PLR_SetCrossing: Team " + team + " exited crossing " + crossingID + " but currentCrossing is 0";
+        }
+        t.currentCrossing = 0;
+        t.waitingAtCrossing = false;
 
-        // Wake up any other team waiting on the same crossing
-        PLR_ForEachTeam(function(other, otherState) {
-            if (other != team && otherState.crossing == t._waitingCrossing) {
-                // The crossing is now free - let the waiting team proceed slowly
-                otherState._waitingCrossing = 0;
-                otherState.pushzone.AcceptInput("Enable", "", null, null);
-                PLR_BlockCart(other, false);
-                EntFireByHandle(otherState.train, "RunScriptCode",
-                    "PLR_Advance(" + other + ", " + otherState.speed1 + ", false)", 0.5, null, null);
-            }
-        });
+        local c = PLR_CROSSINGS[exitedCrossing];
+        if (!c) return;
+
+        // If crossing was disabled (last team), still track but skip blocking logic
+        if (!c.disabled) {
+            t.pushzone.AcceptInput("Enable", "", null, null);
+            PLR_BlockCart(team, false);
+        }
+        c.passed.push(team);
+
+        // Check how many teams haven't passed yet
+        local remaining = 0;
+        foreach(t2 in c.teams) {
+            if (c.passed.find(t2) == null) remaining++;
+        }
+
+        if (remaining <= 1) {
+            // Only one team left - disable crossing logic
+            c.disabled = true;
+            // If the last team is waiting at this crossing, unblock it
+            PLR_ForEachTeam(function(other, otherState) {
+                if (otherState.waitingAtCrossing && otherState.currentCrossing == exitedCrossing) {
+                    otherState.waitingAtCrossing = false;
+                    otherState.pushzone.AcceptInput("Enable", "", null, null);
+                    PLR_BlockCart(other, false);
+                }
+            });
+        } else if (!c.disabled && c.queue.len() > 0) {
+            // Release next team from queue (FIFO) - block input and force through
+            local nextTeam = c.queue.pop();
+            local nextT = PLR_GetTeam(nextTeam);
+            nextT.waitingAtCrossing = false;
+            // Keep pushzone disabled and cart blocked through crossing
+            PLR_BlockCart(nextTeam, true);
+            EntFireByHandle(nextT.train, "RunScriptCode",
+                "PLR_Advance(" + nextTeam + ", " + nextT.speed1 + ", false)", 0.5, null, null);
+        }
     } else {
         // Entering a crossing
-        local conflict = false;
-        local waitingTeam = null;
+        local c = PLR_CROSSINGS[crossingID];
+        if (!c) return;
 
-        // Check if any other team is already in this crossing
+        if (c.disabled) {
+            // Crossing disabled - all other teams already passed, just go through normally
+            t.currentCrossing = crossingID;
+            return;
+        }
+
+        // Check if any team is currently in this crossing
+        local conflict = false;
         PLR_ForEachTeam(function(other, otherState) {
-            if (other != team && otherState.crossing == crossingID) {
+            if (other != team && otherState.currentCrossing == crossingID) {
                 conflict = true;
-                waitingTeam = other;
             }
         });
 
         if (conflict) {
-            // Another team is in this crossing - stop and wait
-            t.crossing = crossingID;
-            t._waitingCrossing <- crossingID;
+            // Another team is in this crossing - queue and wait
+            t.currentCrossing = crossingID;
+            t.waitingAtCrossing = true;
+            c.queue.push(team);
             t.pushzone.AcceptInput("Disable", "", null, null);
             PLR_BlockCart(team, true);
             PLR_Stop(team);
         } else {
-            // Crossing is clear - enter it
-            t.crossing = crossingID;
+            // Crossing is clear - enter, block pushzone, force through at speed1
+            t.currentCrossing = crossingID;
+            t.pushzone.AcceptInput("Disable", "", null, null);
+            PLR_BlockCart(team, true);
+            EntFireByHandle(t.train, "RunScriptCode",
+                "PLR_Advance(" + team + ", " + t.speed1 + ", false)", 0.5, null, null);
         }
     }
 }

--- a/mega_mod/common/plr_overtime.nut
+++ b/mega_mod/common/plr_overtime.nut
@@ -365,11 +365,11 @@ function PLR_AddRollforwardZone(team, startPath, endPath, disablePath) {
     }
 }
 
-// AddCrossing: Register one or more teams on a shared crossing.
+// PLR_AddCrossing: Register one or more teams on a shared crossing.
 // teams: Array of [startPath, endPath, team] triplets.
 // The crossing ID is auto-generated.
-// Example: AddCrossing([["red_start", "red_end", 2], ["blu_start", "blu_end", 3]])
-function AddCrossing(teams) {
+// Example: PLR_AddCrossing([["red_start", "red_end", 2], ["blu_start", "blu_end", 3]])
+function PLR_AddCrossing(teams) {
     local crossingID = PLR_NEXT_CROSSING_ID++;
     if (teams.len() < 2) {
         throw "AddCrossing requires at least 2 teams";
@@ -513,7 +513,7 @@ function PLR_CartThink(team) {
 // ROUND MANAGEMENT
 // ============================================================================
 
-function StartOvertime() {
+function PLR_StartOvertime() {
     ::OVERTIME_ACTIVE <- true;
     if (PLR_TIMER && PLR_TIMER.IsValid()) PLR_TIMER.Kill();
     PLR_ForEachTeam(function(team, state) {
@@ -521,7 +521,7 @@ function StartOvertime() {
     });
 }
 
-function ForceStopCarts() {
+function PLR_ForceStopCarts() {
     if (PLR_TIMER && PLR_TIMER.IsValid()) PLR_TIMER.Kill();
     ::OVERTIME_ACTIVE <- false;
     ::ROLLBACK_DISABLED <- false;
@@ -531,7 +531,7 @@ function ForceStopCarts() {
     });
 }
 
-function ResetCartStates() {
+function PLR_ResetCartStates() {
     ::OVERTIME_ACTIVE <- false;
     ::ROLLBACK_DISABLED <- false;
     local now = Time();
@@ -545,15 +545,15 @@ function ResetCartStates() {
     });
 }
 
-function DisableOvertimeRollback() {
+function PLR_DisableOvertimeRollback() {
     if (ROLLBACK_DISABLED) return;
     ::ROLLBACK_DISABLED <- true;
     if (!OVERTIME_ACTIVE) return;
-    AnnounceRollbackDisabled();
+    PLR_AnnounceRollbackDisabled();
     if (PLR_TIMER && PLR_TIMER.IsValid()) PLR_TIMER.Kill();
 }
 
-function AnnounceRollbackDisabled() {
+function PLR_AnnounceRollbackDisabled() {
     local text_tf = SpawnEntityFromTable("game_text_tf", {
         message = "Rollback zones disabled!",
         icon = "timer_icon",
@@ -568,11 +568,11 @@ function AnnounceRollbackDisabled() {
 // TIMER HELPERS
 // ============================================================================
 
-function GetRoundTimeString(setup = 0) {
-    return "" + GetRoundTime(setup);
+function PLR_GetRoundTimeString(setup = 0) {
+    return "" + PLR_GetRoundTime(setup);
 }
 
-function GetRoundTime(setup = 0) {
+function PLR_GetRoundTime(setup = 0) {
     local time = MM_PLR_TIME_UPPER_LIMIT;
     local timeRemaining = MM_GetTimelimitRemaining();
     if (timeRemaining != null) time = ceil(timeRemaining / 30) * 30;
@@ -586,50 +586,15 @@ function GetRoundTime(setup = 0) {
 // ============================================================================
 
 function OnGameEvent_teamplay_round_win(params) {
-    if (params.team == 2) {
-        WinRed();
-    } else if (params.team == 3) {
-        WinBlu();
+    if (params.team in PLR_TEAMS) {
+        PLR_TeamWin(params.team);
     } else {
-        ForceStopCarts();
+        PLR_TeamWin(0);
     }
 }
 
-function WinRed() {
-    ForceStopCarts();
-}
-
-function WinBlu() {
-    ForceStopCarts();
-}
-
-// ============================================================================
-// LEGACY ALIASES (for entity output strings that use old function names)
-// These use the team string "Red"/"Blu" to determine team number.
-// Map mods should migrate to PLR_* versions.
-// ============================================================================
-
-function CreateLogicCase(name, team) {
-    local t = team == "Red" ? 2 : 3;
-    return PLR_CreateLogicCase(t, name);
-}
-
-function AddCaptureOutputsToLogicCase(entity, team) {
-    local t = team == "Red" ? 2 : 3;
-    PLR_AddCaptureOutputsToLogicCase(t, entity);
-}
-
-function AddRollbackZone(startPath, endPath, disablePath, team) {
-    local t = team == "Red" ? 2 : 3;
-    PLR_AddRollbackZone(t, startPath, endPath, disablePath);
-}
-
-function AddRollforwardZone(startPath, endPath, disablePath, team) {
-    local t = team == "Red" ? 2 : 3;
-    PLR_AddRollforwardZone(t, startPath, endPath, disablePath);
+function PLR_TeamWin(team) {
+    PLR_ForceStopCarts();
 }
 
 
-function CreateCartAutoUpdater(cart, team) {
-    PLR_CreateCartAutoUpdater(team, cart);
-}

--- a/mega_mod/common/plr_overtime.nut
+++ b/mega_mod/common/plr_overtime.nut
@@ -13,7 +13,7 @@
 ::PLR_CROSSINGS <- {}  // crossingID => { teams: [team,...], passed: [], queue: [team,...], disabled: false }
 ::PLR_UPDATE_DEPTH <- 0
 ::PLR_NEXT_CROSSING_ID <- 1
-const PLR_MAX_UPDATE_DEPTH = 8  // N teams + safety margin
+::PLR_MAX_UPDATE_DEPTH <- 8  // N teams + safety margin
 
 function PLR_RegisterTeam(team, config) {
     local rollbackSpeed = -1.0;

--- a/mega_mod/mapmods/plr_bananabay.nut
+++ b/mega_mod/mapmods/plr_bananabay.nut
@@ -100,8 +100,8 @@ function OnGameEvent_teamplay_round_start(params) {
 
     // Timer logic replacement
     EntityOutputs.RemoveOutput(PLR_TIMER, "OnSetupFinished", PLR_TIMER_NAME, "Disable", "");
-    EntityOutputs.AddOutput(PLR_TIMER, "OnSetupFinished", "!self", "SetTime", GetRoundTimeString(), 0, -1);
-    EntityOutputs.AddOutput(PLR_TIMER, "OnFinished", "!self", "RunScriptCode", "StartOvertime()", 0, -1);
+    EntityOutputs.AddOutput(PLR_TIMER, "OnSetupFinished", "!self", "SetTime", PLR_GetRoundTimeString(), 0, -1);
+    EntityOutputs.AddOutput(PLR_TIMER, "OnFinished", "!self", "RunScriptCode", "PLR_StartOvertime()", 0, -1);
 
     // Add thinks to carts
     PLR_CreateCartAutoUpdater(2, PLR_TEAMS[2].train);

--- a/mega_mod/mapmods/plr_bananabay.nut
+++ b/mega_mod/mapmods/plr_bananabay.nut
@@ -43,8 +43,8 @@ function OnGameEvent_teamplay_round_start(params) {
     PLR_AddRollbackZone(3, "minecart_bpath_80", null, "minecart_bpath_88");
 
     // Track if the cart is at the cutoff between the track and the capture zone
-    PLR_TEAMS[2].custom.atCutoff = false;
-    PLR_TEAMS[3].custom.atCutoff = false;
+    PLR_TEAMS[2].custom.atCutoff <- false;
+    PLR_TEAMS[3].custom.atCutoff <- false;
 
     EntityOutputs.AddOutput(MM_GetEntByName("minecart_path_81"), "OnPass", "!self", "RunScriptCode", "PLR_TEAMS[2].custom.atCutoff = false", 0, -1);
     EntityOutputs.AddOutput(MM_GetEntByName("minecart_path_82"), "OnPass", "!self", "RunScriptCode", "PLR_TEAMS[2].custom.atCutoff = true", 0, -1);
@@ -57,8 +57,8 @@ function OnGameEvent_teamplay_round_start(params) {
     EntityOutputs.AddOutput(MM_GetEntByName("minecart_bpath_86"), "OnPass", "!self", "RunScriptCode", "PLR_TEAMS[3].custom.atCutoff = false", 0, -1);
 
     // Track if the cart is at the very end of the track.
-    PLR_TEAMS[2].custom.atEnd = false;
-    PLR_TEAMS[3].custom.atEnd = false;
+    PLR_TEAMS[2].custom.atEnd <- false;
+    PLR_TEAMS[3].custom.atEnd <- false;
 
     EntityOutputs.AddOutput(MM_GetEntByName("minecart_path_85"), "OnPass", "!self", "RunScriptCode", "PLR_TEAMS[2].custom.atEnd = false; PLR_UpdateCart(2, PLR_TEAMS[2].pushstate)", 0, -1);
     EntityOutputs.AddOutput(MM_GetEntByName("minecart_red_pathA_end"), "OnPass", "!self", "RunScriptCode", "PLR_TEAMS[2].custom.atEnd = true", 0, -1);
@@ -120,8 +120,7 @@ function CheckCart(team) {
 
 // Do not move cart forward if it's already at the end of the track.
 ::PLR_Advance_Base <- PLR_Advance;
-function PLR_Advance(team, speed, dynamic) {
-    if (dynamic == null) dynamic = true;
+function PLR_Advance(team, speed, dynamic = true) {
     local t = PLR_GetTeam(team);
     if (t.custom.atEnd && speed > 0) return;
     PLR_Advance_Base(team, speed, dynamic);

--- a/mega_mod/mapmods/plr_bananabay.nut
+++ b/mega_mod/mapmods/plr_bananabay.nut
@@ -8,76 +8,72 @@ function OnGameEvent_teamplay_round_start(params) {
     ::PLR_TIMER_NAME <- "minecart_timer";
     ::PLR_TIMER = MM_GetEntByName(PLR_TIMER_NAME);
 
-    ::RED_CARTSPARKS_ARRAY <- MM_GetEntArrayByName("minecart_red_cartsparks");
-    ::BLU_CARTSPARKS_ARRAY <- MM_GetEntArrayByName("minecart_blu_cartsparks");
+    PLR_TEAMS[2].cartsparks = MM_GetEntArrayByName("minecart_red_cartsparks");
+    PLR_TEAMS[3].cartsparks = MM_GetEntArrayByName("minecart_blu_cartsparks");
 
-    ::RED_FLASHINGLIGHT <- MM_GetEntByName("minecart_red_flashinglight");
-    ::BLU_FLASHINGLIGHT <- MM_GetEntByName("minecart_blu_flashinglight");
+    PLR_TEAMS[2].flashinglight = MM_GetEntByName("minecart_red_flashinglight");
+    PLR_TEAMS[3].flashinglight = MM_GetEntByName("minecart_blu_flashinglight");
 
-    ::RED_PUSHZONE <- MM_GetEntByName("minecart_red_pushzone");
-    ::BLU_PUSHZONE <- MM_GetEntByName("minecart_blu_pushzone");
+    PLR_TEAMS[2].pushzone = MM_GetEntByName("minecart_red_pushzone");
+    PLR_TEAMS[3].pushzone = MM_GetEntByName("minecart_blu_pushzone");
 
-    ::RED_TRAIN <- MM_GetEntByName("minecart_red_train");
-    ::BLU_TRAIN <- MM_GetEntByName("minecart_blu_train");
+    PLR_TEAMS[2].train = MM_GetEntByName("minecart_red_train");
+    PLR_TEAMS[3].train = MM_GetEntByName("minecart_blu_train");
 
-    ::RED_LOGICCASE <- CreateLogicCase("mm_plr_logiccase_red", "Red");
-    ::BLU_LOGICCASE <- CreateLogicCase("mm_plr_logiccase_blu", "Blu");
+    PLR_TEAMS[2].logiccase = PLR_CreateLogicCase(2, "mm_plr_logiccase_red");
+    PLR_TEAMS[3].logiccase = PLR_CreateLogicCase(3, "mm_plr_logiccase_blu");
 
-    ::RED_WATCHER <- MM_GetEntByName("minecart_red_watcherA");
-    ::BLU_WATCHER <- MM_GetEntByName("minecart_blu_watcherA");
+    PLR_TEAMS[2].watcher = MM_GetEntByName("minecart_red_watcherA");
+    PLR_TEAMS[3].watcher = MM_GetEntByName("minecart_blu_watcherA");
 
-    EntityOutputs.AddOutput(RED_PUSHZONE, "OnNumCappersChanged2", "mm_plr_logiccase_red", "InValue", "", 0, -1);
-    EntityOutputs.AddOutput(BLU_PUSHZONE, "OnNumCappersChanged2", "mm_plr_logiccase_blu", "InValue", "", 0, -1);
+    EntityOutputs.AddOutput(PLR_TEAMS[2].pushzone, "OnNumCappersChanged2", "mm_plr_logiccase_red", "InValue", "", 0, -1);
+    EntityOutputs.AddOutput(PLR_TEAMS[3].pushzone, "OnNumCappersChanged2", "mm_plr_logiccase_blu", "InValue", "", 0, -1);
 
-    // Rollzones RED
+    // Rollzones
+    PLR_AddRollbackZone(2, "minecart_path_36", "minecart_path_38", "minecart_path_35");
+    PLR_AddRollforwardZone(2, "minecart_path_48", "minecart_path_52", "minecart_path_51");
+    PLR_AddRollbackZone(2, "minecart_path_57", "minecart_path_68", "minecart_path_56");
+    PLR_AddRollbackZone(2, "minecart_path_77", "minecart_path_78", "minecart_path_76");
+    PLR_AddRollbackZone(2, "minecart_path_88", null, "minecart_path_87");
 
-    AddRollbackZone("minecart_path_36", "minecart_path_38", "minecart_path_35", "Red");
-    AddRollforwardZone("minecart_path_48", "minecart_path_52", "minecart_path_51", "Red");
-    AddRollbackZone("minecart_path_57", "minecart_path_68", "minecart_path_56", "Red");
-    AddRollbackZone("minecart_path_77", "minecart_path_78", "minecart_path_76", "Red");
-    AddRollbackZone("minecart_path_88", null, "minecart_path_87", "Red");
-
-    // Rollzones BLU
-
-    AddRollbackZone("minecart_bpath_36", "minecart_bpath_38", "minecart_bpath_35", "Blu");
-    AddRollforwardZone("minecart_bpath_48", "minecart_bpath_52", "minecart_bpath_51", "Blu");
-    AddRollbackZone("minecart_bpath_57", "minecart_bpath_68", "minecart_bpath_56", "Blu");
-    AddRollbackZone("minecart_bpath_77", "minecart_bpath_78", "minecart_bpath_76", "Blu");
-    AddRollbackZone("minecart_bpath_80", null, "minecart_bpath_88", "Blu");
+    PLR_AddRollbackZone(3, "minecart_bpath_36", "minecart_bpath_38", "minecart_bpath_35");
+    PLR_AddRollforwardZone(3, "minecart_bpath_48", "minecart_bpath_52", "minecart_bpath_51");
+    PLR_AddRollbackZone(3, "minecart_bpath_57", "minecart_bpath_68", "minecart_bpath_56");
+    PLR_AddRollbackZone(3, "minecart_bpath_77", "minecart_bpath_78", "minecart_bpath_76");
+    PLR_AddRollbackZone(3, "minecart_bpath_80", null, "minecart_bpath_88");
 
     // Track if the cart is at the cutoff between the track and the capture zone
-    // where the cart stops during the train event.
-    ::RED_AT_CUTOFF <- false;
-    ::BLU_AT_CUTOFF <- false;
+    PLR_TEAMS[2].custom.atCutoff = false;
+    PLR_TEAMS[3].custom.atCutoff = false;
 
-    EntityOutputs.AddOutput(MM_GetEntByName("minecart_path_81"), "OnPass", "!self", "RunScriptCode", "::RED_AT_CUTOFF <- false", 0, -1);
-    EntityOutputs.AddOutput(MM_GetEntByName("minecart_path_82"), "OnPass", "!self", "RunScriptCode", "::RED_AT_CUTOFF <- true", 0, -1);
-    EntityOutputs.AddOutput(MM_GetEntByName("minecart_path_84"), "OnPass", "!self", "RunScriptCode", "::RED_AT_CUTOFF <- true", 0, -1);
-    EntityOutputs.AddOutput(MM_GetEntByName("minecart_path_86"), "OnPass", "!self", "RunScriptCode", "::RED_AT_CUTOFF <- false", 0, -1);
+    EntityOutputs.AddOutput(MM_GetEntByName("minecart_path_81"), "OnPass", "!self", "RunScriptCode", "PLR_TEAMS[2].custom.atCutoff = false", 0, -1);
+    EntityOutputs.AddOutput(MM_GetEntByName("minecart_path_82"), "OnPass", "!self", "RunScriptCode", "PLR_TEAMS[2].custom.atCutoff = true", 0, -1);
+    EntityOutputs.AddOutput(MM_GetEntByName("minecart_path_84"), "OnPass", "!self", "RunScriptCode", "PLR_TEAMS[2].custom.atCutoff = true", 0, -1);
+    EntityOutputs.AddOutput(MM_GetEntByName("minecart_path_86"), "OnPass", "!self", "RunScriptCode", "PLR_TEAMS[2].custom.atCutoff = false", 0, -1);
 
-    EntityOutputs.AddOutput(MM_GetEntByName("minecart_bpath_82"), "OnPass", "!self", "RunScriptCode", "::BLU_AT_CUTOFF <- false", 0, -1);
-    EntityOutputs.AddOutput(MM_GetEntByName("minecart_bpath_89"), "OnPass", "!self", "RunScriptCode", "::BLU_AT_CUTOFF <- true", 0, -1);
-    EntityOutputs.AddOutput(MM_GetEntByName("minecart_bpath_83"), "OnPass", "!self", "RunScriptCode", "::BLU_AT_CUTOFF <- true", 0, -1);
-    EntityOutputs.AddOutput(MM_GetEntByName("minecart_bpath_86"), "OnPass", "!self", "RunScriptCode", "::BLU_AT_CUTOFF <- false", 0, -1);
+    EntityOutputs.AddOutput(MM_GetEntByName("minecart_bpath_82"), "OnPass", "!self", "RunScriptCode", "PLR_TEAMS[3].custom.atCutoff = false", 0, -1);
+    EntityOutputs.AddOutput(MM_GetEntByName("minecart_bpath_89"), "OnPass", "!self", "RunScriptCode", "PLR_TEAMS[3].custom.atCutoff = true", 0, -1);
+    EntityOutputs.AddOutput(MM_GetEntByName("minecart_bpath_83"), "OnPass", "!self", "RunScriptCode", "PLR_TEAMS[3].custom.atCutoff = true", 0, -1);
+    EntityOutputs.AddOutput(MM_GetEntByName("minecart_bpath_86"), "OnPass", "!self", "RunScriptCode", "PLR_TEAMS[3].custom.atCutoff = false", 0, -1);
 
     // Track if the cart is at the very end of the track.
-    ::RED_AT_END <- false;
-    ::BLU_AT_END <- false;
+    PLR_TEAMS[2].custom.atEnd = false;
+    PLR_TEAMS[3].custom.atEnd = false;
 
-    EntityOutputs.AddOutput(MM_GetEntByName("minecart_path_85"), "OnPass", "!self", "RunScriptCode", "::RED_AT_END <- false; UpdateRedCart(CASE_RED)", 0, -1);
-    EntityOutputs.AddOutput(MM_GetEntByName("minecart_red_pathA_end"), "OnPass", "!self", "RunScriptCode", "::RED_AT_END <- true", 0, -1);
+    EntityOutputs.AddOutput(MM_GetEntByName("minecart_path_85"), "OnPass", "!self", "RunScriptCode", "PLR_TEAMS[2].custom.atEnd = false; PLR_UpdateCart(2, PLR_TEAMS[2].pushstate)", 0, -1);
+    EntityOutputs.AddOutput(MM_GetEntByName("minecart_red_pathA_end"), "OnPass", "!self", "RunScriptCode", "PLR_TEAMS[2].custom.atEnd = true", 0, -1);
 
-    EntityOutputs.AddOutput(MM_GetEntByName("minecart_bpath_85"), "OnPass", "!self", "RunScriptCode", "::BLU_AT_END <- false; UpdateBluCart(CASE_BLU)", 0, -1);
-    EntityOutputs.AddOutput(MM_GetEntByName("minecart_blu_pathA_end"), "OnPass", "!self", "RunScriptCode", "::BLU_AT_END <- true", 0, -1);
+    EntityOutputs.AddOutput(MM_GetEntByName("minecart_bpath_85"), "OnPass", "!self", "RunScriptCode", "PLR_TEAMS[3].custom.atEnd = false; PLR_UpdateCart(3, PLR_TEAMS[3].pushstate)", 0, -1);
+    EntityOutputs.AddOutput(MM_GetEntByName("minecart_blu_pathA_end"), "OnPass", "!self", "RunScriptCode", "PLR_TEAMS[3].custom.atEnd = true", 0, -1);
 
     // Check if the cart needs updating.
-    EntityOutputs.AddOutput(MM_GetEntByName("path_mid_a7"), "OnPass", "!self", "RunScriptCode", "CheckCartRed()", 0, -1);
-    EntityOutputs.AddOutput(MM_GetEntByName("path_mid_a10"), "OnPass", "!self", "RunScriptCode", "CheckCartRed()", 0, -1);
-    EntityOutputs.AddOutput(MM_GetEntByName("relay_enable_red_cap"), "OnTrigger", "!self", "RunScriptCode", "CheckCartRed()", 0, -1);
+    EntityOutputs.AddOutput(MM_GetEntByName("path_mid_a7"), "OnPass", "!self", "RunScriptCode", "CheckCart(2)", 0, -1);
+    EntityOutputs.AddOutput(MM_GetEntByName("path_mid_a10"), "OnPass", "!self", "RunScriptCode", "CheckCart(2)", 0, -1);
+    EntityOutputs.AddOutput(MM_GetEntByName("relay_enable_red_cap"), "OnTrigger", "!self", "RunScriptCode", "CheckCart(2)", 0, -1);
 
-    EntityOutputs.AddOutput(MM_GetEntByName("path_mid_a7"), "OnPass", "!self", "RunScriptCode", "CheckCartBlu()", 0, -1);
-    EntityOutputs.AddOutput(MM_GetEntByName("path_mid_a10"), "OnPass", "!self", "RunScriptCode", "CheckCartBlu()", 0, -1);
-    EntityOutputs.AddOutput(MM_GetEntByName("relay_enable_blu_cap"), "OnTrigger", "!self", "RunScriptCode", "CheckCartBlu()", 0, -1);
+    EntityOutputs.AddOutput(MM_GetEntByName("path_mid_a7"), "OnPass", "!self", "RunScriptCode", "CheckCart(3)", 0, -1);
+    EntityOutputs.AddOutput(MM_GetEntByName("path_mid_a10"), "OnPass", "!self", "RunScriptCode", "CheckCart(3)", 0, -1);
+    EntityOutputs.AddOutput(MM_GetEntByName("relay_enable_blu_cap"), "OnTrigger", "!self", "RunScriptCode", "CheckCart(3)", 0, -1);
 
     // Remove old cart update logic
     EntityOutputs.RemoveOutput(MM_GetEntByName("path_mid_a7"), "OnPass", "minecart_red_pushzone", "Disable", "");
@@ -96,11 +92,11 @@ function OnGameEvent_teamplay_round_start(params) {
     EntityOutputs.RemoveOutput(MM_GetEntByName("relay_enable_blu_cap"), "OnTrigger", "minecart_blu_pushzone", "Enable", "");
 
     // team_train_watcher is no longer in charge.
-    NetProps.SetPropBool(RED_WATCHER, "m_bHandleTrainMovement", false);
-    NetProps.SetPropBool(BLU_WATCHER, "m_bHandleTrainMovement", false);
+    NetProps.SetPropBool(PLR_TEAMS[2].watcher, "m_bHandleTrainMovement", false);
+    NetProps.SetPropBool(PLR_TEAMS[3].watcher, "m_bHandleTrainMovement", false);
 
-    EntityOutputs.AddOutput(RED_PUSHZONE, "OnNumCappersChanged2", "minecart_red_watcherA", "SetNumTrainCappers", "", 0, -1);
-    EntityOutputs.AddOutput(BLU_PUSHZONE, "OnNumCappersChanged2", "minecart_blu_watcherA", "SetNumTrainCappers", "", 0, -1);
+    EntityOutputs.AddOutput(PLR_TEAMS[2].pushzone, "OnNumCappersChanged2", "minecart_red_watcherA", "SetNumTrainCappers", "", 0, -1);
+    EntityOutputs.AddOutput(PLR_TEAMS[3].pushzone, "OnNumCappersChanged2", "minecart_blu_watcherA", "SetNumTrainCappers", "", 0, -1);
 
     // Timer logic replacement
     EntityOutputs.RemoveOutput(PLR_TIMER, "OnSetupFinished", PLR_TIMER_NAME, "Disable", "");
@@ -108,49 +104,35 @@ function OnGameEvent_teamplay_round_start(params) {
     EntityOutputs.AddOutput(PLR_TIMER, "OnFinished", "!self", "RunScriptCode", "StartOvertime()", 0, -1);
 
     // Add thinks to carts
-    CreateCartAutoUpdater(RED_TRAIN, 2);
-    CreateCartAutoUpdater(BLU_TRAIN, 3);
+    PLR_CreateCartAutoUpdater(2, PLR_TEAMS[2].train);
+    PLR_CreateCartAutoUpdater(3, PLR_TEAMS[3].train);
 }
 
 // Update carts at the cutoff when train event finishes (carts at cutoff don't autoresume)
-function CheckCartRed() {
+function CheckCart(team) {
+    local t = PLR_GetTeam(team);
     // Don't need to autoresume if the cart should be stationary.
-    if (CASE_RED == 0 && !OVERTIME_ACTIVE) return;
-    if (!RED_AT_CUTOFF) return;
+    if (t.pushstate == 0 && !OVERTIME_ACTIVE) return;
+    if (!t.custom.atCutoff) return;
 
-    // printl("CHECK CART RED");
-    UpdateRedCart(CASE_RED);
-}
-
-function CheckCartBlu() {
-    // Don't need to autoresume if the cart should be stationary.
-    if (CASE_BLU == 0 && !OVERTIME_ACTIVE) return;
-    if (!BLU_AT_CUTOFF) return;
-
-    // printl("CHECK CART BLU");
-    UpdateBluCart(CASE_BLU);
+    PLR_UpdateCart(team, t.pushstate);
 }
 
 // Do not move cart forward if it's already at the end of the track.
-::AdvanceRedBase <- AdvanceRed;
-::AdvanceBluBase <- AdvanceBlu;
-
-function AdvanceRed(speed, dynamic = true) {
-    if (RED_AT_END && speed > 0) return;
-    AdvanceRedBase(speed, dynamic);
-}
-
-function AdvanceBlu(speed, dynamic = true) {
-    if (BLU_AT_END && speed > 0) return;
-    AdvanceBluBase(speed, dynamic);
+::PLR_Advance_Base <- PLR_Advance;
+function PLR_Advance(team, speed, dynamic) {
+    if (dynamic == null) dynamic = true;
+    local t = PLR_GetTeam(team);
+    if (t.custom.atEnd && speed > 0) return;
+    PLR_Advance_Base(team, speed, dynamic);
 }
 
 // Stop thinks from needlessly checking cart (causes cart sounds to play when they shouldn't)
-::CartThinkBase <- CartThink;
-function CartThink(team) {
-    if (team == 2 && (RED_AT_END || RED_AT_CUTOFF)) return;
-    if (team == 3 && (BLU_AT_END || BLU_AT_CUTOFF)) return;
-    return CartThinkBase(team);
+::PLR_CartThink_Base <- PLR_CartThink;
+function PLR_CartThink(team) {
+    local t = PLR_GetTeam(team);
+    if (t.custom.atEnd || t.custom.atCutoff) return 0.5;
+    return PLR_CartThink_Base(team);
 }
 
 __CollectGameEventCallbacks(this);

--- a/mega_mod/mapmods/plr_cutter.nut
+++ b/mega_mod/mapmods/plr_cutter.nut
@@ -8,36 +8,33 @@ function OnGameEvent_teamplay_round_start(params) {
     ::PLR_TIMER_NAME <- "plr_timer";
     ::PLR_TIMER = MM_GetEntByName(PLR_TIMER_NAME);
 
-    ::RED_CARTSPARKS_ARRAY <- MM_GetEntArrayByName("plr_red_cartsparks");
-    ::BLU_CARTSPARKS_ARRAY <- MM_GetEntArrayByName("plr_blu_cartsparks");
+    PLR_TEAMS[2].cartsparks = MM_GetEntArrayByName("plr_red_cartsparks");
+    PLR_TEAMS[3].cartsparks = MM_GetEntArrayByName("plr_blu_cartsparks");
 
-    ::RED_PUSHZONE <- MM_GetEntByName("plr_red_pushzone");
-    ::BLU_PUSHZONE <- MM_GetEntByName("plr_blu_pushzone");
+    PLR_TEAMS[2].pushzone = MM_GetEntByName("plr_red_pushzone");
+    PLR_TEAMS[3].pushzone = MM_GetEntByName("plr_blu_pushzone");
 
-    ::RED_TRAIN <- MM_GetEntByName("plr_red_train");
-    ::BLU_TRAIN <- MM_GetEntByName("plr_blu_train");
+    PLR_TEAMS[2].train = MM_GetEntByName("plr_red_train");
+    PLR_TEAMS[3].train = MM_GetEntByName("plr_blu_train");
 
-    ::RED_LOGICCASE <- CreateLogicCase("mm_plr_logiccase_red", "Red");
-    ::BLU_LOGICCASE <- CreateLogicCase("mm_plr_logiccase_blu", "Blu");
+    PLR_TEAMS[2].logiccase = PLR_CreateLogicCase(2, "mm_plr_logiccase_red");
+    PLR_TEAMS[3].logiccase = PLR_CreateLogicCase(3, "mm_plr_logiccase_blu");
 
-    ::RED_WATCHER <- MM_GetEntByName("plr_red_watcherA");
-    ::BLU_WATCHER <- MM_GetEntByName("plr_blu_watcherA");
+    PLR_TEAMS[2].watcher = MM_GetEntByName("plr_red_watcherA");
+    PLR_TEAMS[3].watcher = MM_GetEntByName("plr_blu_watcherA");
 
-    EntityOutputs.AddOutput(RED_PUSHZONE, "OnNumCappersChanged2", "mm_plr_logiccase_red", "InValue", "", 0, -1);
-    EntityOutputs.AddOutput(BLU_PUSHZONE, "OnNumCappersChanged2", "mm_plr_logiccase_blu", "InValue", "", 0, -1);
+    EntityOutputs.AddOutput(PLR_TEAMS[2].pushzone, "OnNumCappersChanged2", "mm_plr_logiccase_red", "InValue", "", 0, -1);
+    EntityOutputs.AddOutput(PLR_TEAMS[3].pushzone, "OnNumCappersChanged2", "mm_plr_logiccase_blu", "InValue", "", 0, -1);
 
-    // Rollzones RED
-    AddRollbackZone("path_red_rollback2_1", "path_red_rollback2_5", "path_red_256CCW_2_9", "Red");
-    AddRollbackZone("path_red_rollback3_1", "path_red_rollback3_5", "path_red_45bCCW_2_4", "Red");
-    AddRollbackZone("path_red_finalhill1", "plr_red_pathA_end", "path_red_128CCW_3_5", "Red");
-
-    // Rollzones BLU
-    AddRollbackZone("path_blu_rollback2_1", "path_blu_rollback2_5", "path_blu_256CCW_2_9", "Blu");
-    AddRollbackZone("path_blu_rollback3_1", "path_blu_rollback3_5", "path_blu_45bCCW_2_4", "Blu");
-    AddRollbackZone("path_blu_finalhill1", "plr_blu_pathA_end", "path_blu_finalhill1", "Blu");
+    // Rollzones
+    PLR_AddRollbackZone(2, "path_red_rollback2_1", "path_red_rollback2_5", "path_red_256CCW_2_9");
+    PLR_AddRollbackZone(2, "path_red_rollback3_1", "path_red_rollback3_5", "path_red_45bCCW_2_4");
+    PLR_AddRollbackZone(2, "path_red_finalhill1", "plr_red_pathA_end", "path_red_128CCW_3_5");
+    PLR_AddRollbackZone(3, "path_blu_rollback2_1", "path_blu_rollback2_5", "path_blu_256CCW_2_9");
+    PLR_AddRollbackZone(3, "path_blu_rollback3_1", "path_blu_rollback3_5", "path_blu_45bCCW_2_4");
+    PLR_AddRollbackZone(3, "path_blu_finalhill1", "plr_blu_pathA_end", "path_blu_finalhill1");
 
     // Crossing logic replacement
-
     foreach(entName in [
         "plr_red_crossover1_branch"
         "plr_red_crossover1_relay"
@@ -47,14 +44,17 @@ function OnGameEvent_teamplay_round_start(params) {
         MM_GetEntByName(entName).Kill();
     }
 
-    AddCrossing("plr_red_crossover1_start", "plr_red_crossover1_end", "plr_blu_crossover1_start", "plr_blu_crossover1_end", 1);
+    AddCrossing([
+        ["plr_red_crossover1_start", "plr_red_crossover1_end", 2],
+        ["plr_blu_crossover1_start", "plr_blu_crossover1_end", 3]
+    ]);
 
     // team_train_watcher is no longer in charge.
-    NetProps.SetPropBool(RED_WATCHER, "m_bHandleTrainMovement", false);
-    NetProps.SetPropBool(BLU_WATCHER, "m_bHandleTrainMovement", false);
+    NetProps.SetPropBool(PLR_TEAMS[2].watcher, "m_bHandleTrainMovement", false);
+    NetProps.SetPropBool(PLR_TEAMS[3].watcher, "m_bHandleTrainMovement", false);
 
-    EntityOutputs.AddOutput(RED_PUSHZONE, "OnNumCappersChanged2", "plr_red_watcherA", "SetNumTrainCappers", "", 0, -1);
-    EntityOutputs.AddOutput(BLU_PUSHZONE, "OnNumCappersChanged2", "plr_blu_watcherA", "SetNumTrainCappers", "", 0, -1);
+    EntityOutputs.AddOutput(PLR_TEAMS[2].pushzone, "OnNumCappersChanged2", "plr_red_watcherA", "SetNumTrainCappers", "", 0, -1);
+    EntityOutputs.AddOutput(PLR_TEAMS[3].pushzone, "OnNumCappersChanged2", "plr_blu_watcherA", "SetNumTrainCappers", "", 0, -1);
 
     // Timer logic replacement
     EntityOutputs.RemoveOutput(PLR_TIMER, "OnSetupFinished", PLR_TIMER_NAME, "Disable", "");
@@ -62,8 +62,8 @@ function OnGameEvent_teamplay_round_start(params) {
     EntityOutputs.AddOutput(PLR_TIMER, "OnFinished", "!self", "RunScriptCode", "StartOvertime()", 0, -1);
 
     // Add thinks to carts
-    CreateCartAutoUpdater(RED_TRAIN, 2);
-    CreateCartAutoUpdater(BLU_TRAIN, 3);
+    PLR_CreateCartAutoUpdater(2, PLR_TEAMS[2].train);
+    PLR_CreateCartAutoUpdater(3, PLR_TEAMS[3].train);
 }
 
 __CollectGameEventCallbacks(this);

--- a/mega_mod/mapmods/plr_cutter.nut
+++ b/mega_mod/mapmods/plr_cutter.nut
@@ -44,7 +44,7 @@ function OnGameEvent_teamplay_round_start(params) {
         MM_GetEntByName(entName).Kill();
     }
 
-    AddCrossing([
+    PLR_AddCrossing([
         ["plr_red_crossover1_start", "plr_red_crossover1_end", 2],
         ["plr_blu_crossover1_start", "plr_blu_crossover1_end", 3]
     ]);
@@ -58,8 +58,8 @@ function OnGameEvent_teamplay_round_start(params) {
 
     // Timer logic replacement
     EntityOutputs.RemoveOutput(PLR_TIMER, "OnSetupFinished", PLR_TIMER_NAME, "Disable", "");
-    EntityOutputs.AddOutput(PLR_TIMER, "OnSetupFinished", "!self", "SetTime", GetRoundTimeString(), 0, -1);
-    EntityOutputs.AddOutput(PLR_TIMER, "OnFinished", "!self", "RunScriptCode", "StartOvertime()", 0, -1);
+    EntityOutputs.AddOutput(PLR_TIMER, "OnSetupFinished", "!self", "SetTime", PLR_GetRoundTimeString(), 0, -1);
+    EntityOutputs.AddOutput(PLR_TIMER, "OnFinished", "!self", "RunScriptCode", "PLR_StartOvertime()", 0, -1);
 
     // Add thinks to carts
     PLR_CreateCartAutoUpdater(2, PLR_TEAMS[2].train);

--- a/mega_mod/mapmods/plr_hacksaw.nut
+++ b/mega_mod/mapmods/plr_hacksaw.nut
@@ -67,15 +67,15 @@ function OnGameEvent_teamplay_round_start(params) {
         MM_GetEntByName(entName).Kill();
     }
 
-    AddCrossing([
+    PLR_AddCrossing([
         ["ssplr_red_crossover1_start", "ssplr_red_crossover1_end", 2],
         ["ssplr_blu_crossover1_start", "ssplr_blu_crossover1_end", 3]
     ]);
-    AddCrossing([
+    PLR_AddCrossing([
         ["ssplr_red_pathA_start55", "ssplr_red_pathA_start56", 2],
         ["ssplr_blu_pathA_start59", "ssplr_blu_pathA_start60", 3]
     ]);
-    AddCrossing([
+    PLR_AddCrossing([
         ["ssplr_red_pathA_start80", "ssplr_red_pathA_start81", 2],
         ["ssplr_blu_pathA_start83", "ssplr_blu_pathA_start84", 3]
     ]);
@@ -89,8 +89,8 @@ function OnGameEvent_teamplay_round_start(params) {
 
     // Timer logic replacement
     EntityOutputs.RemoveOutput(PLR_TIMER, "OnSetupFinished", PLR_TIMER_NAME, "Disable", "");
-    EntityOutputs.AddOutput(PLR_TIMER, "OnSetupFinished", "!self", "SetTime", GetRoundTimeString(), 0, -1);
-    EntityOutputs.AddOutput(PLR_TIMER, "OnFinished", "!self", "RunScriptCode", "StartOvertime()", 0, -1);
+    EntityOutputs.AddOutput(PLR_TIMER, "OnSetupFinished", "!self", "SetTime", PLR_GetRoundTimeString(), 0, -1);
+    EntityOutputs.AddOutput(PLR_TIMER, "OnFinished", "!self", "RunScriptCode", "PLR_StartOvertime()", 0, -1);
 
     // Add thinks to carts
     PLR_CreateCartAutoUpdater(2, PLR_TEAMS[2].train);

--- a/mega_mod/mapmods/plr_hacksaw.nut
+++ b/mega_mod/mapmods/plr_hacksaw.nut
@@ -8,40 +8,25 @@ function OnGameEvent_teamplay_round_start(params) {
     ::PLR_TIMER_NAME <- "ssplr_timer";
     ::PLR_TIMER = MM_GetEntByName(PLR_TIMER_NAME);
 
-    ::RED_CARTSPARKS_ARRAY <- MM_GetEntArrayByName("ssplr_red_cartsparks");
-    ::BLU_CARTSPARKS_ARRAY <- MM_GetEntArrayByName("ssplr_blu_cartsparks");
+    PLR_TEAMS[2].cartsparks = MM_GetEntArrayByName("ssplr_red_cartsparks");
+    PLR_TEAMS[3].cartsparks = MM_GetEntArrayByName("ssplr_blu_cartsparks");
 
-    ::RED_PUSHZONE <- MM_GetEntByName("plr_red_pushzone");
-    ::BLU_PUSHZONE <- MM_GetEntByName("plr_blu_pushzone");
+    PLR_TEAMS[2].pushzone = MM_GetEntByName("plr_red_pushzone");
+    PLR_TEAMS[3].pushzone = MM_GetEntByName("plr_blu_pushzone");
 
-    ::RED_TRAIN <- MM_GetEntByName("plr_red_train");
-    ::BLU_TRAIN <- MM_GetEntByName("plr_blu_train");
+    PLR_TEAMS[2].train = MM_GetEntByName("plr_red_train");
+    PLR_TEAMS[3].train = MM_GetEntByName("plr_blu_train");
 
-    ::RED_LOGICCASE <- CreateLogicCase("mm_plr_logiccase_red", "Red");
-    ::BLU_LOGICCASE <- CreateLogicCase("mm_plr_logiccase_blu", "Blu");
+    PLR_TEAMS[2].logiccase = PLR_CreateLogicCase(2, "mm_plr_logiccase_red");
+    PLR_TEAMS[3].logiccase = PLR_CreateLogicCase(3, "mm_plr_logiccase_blu");
 
-    ::RED_WATCHER <- MM_GetEntByName("plr_red_watcher");
-    ::BLU_WATCHER <- MM_GetEntByName("plr_blu_watcher");
+    PLR_TEAMS[2].watcher = MM_GetEntByName("plr_red_watcher");
+    PLR_TEAMS[3].watcher = MM_GetEntByName("plr_blu_watcher");
 
-    EntityOutputs.AddOutput(RED_PUSHZONE, "OnNumCappersChanged2", "mm_plr_logiccase_red", "InValue", "", 0, -1);
-    EntityOutputs.AddOutput(BLU_PUSHZONE, "OnNumCappersChanged2", "mm_plr_logiccase_blu", "InValue", "", 0, -1);
-
-    // Some rollback zones are improperly marked. This removes the uphill spawnflag from the offending path_track entities
-    // TODO: Find a way to update team_train_watcher entities to reflect these changes
-    // foreach(entName in [
-    //     "ssplr_red_pathA_start83",
-    //     "ssplr_red_pathA_start73",
-    //     "ssplr_red_pathA_start79",
-    //     "ssplr_blu_pathA_start87",
-    //     "ssplr_blu_pathA_start77",
-    //     "ssplr_blu_pathA_start89"
-    // ]) {
-    //     EntFireByHandle(MM_GetEntByName(entName), "AddOutput", "spawnflags 0", 0, null, null);
-    // }
+    EntityOutputs.AddOutput(PLR_TEAMS[2].pushzone, "OnNumCappersChanged2", "mm_plr_logiccase_red", "InValue", "", 0, -1);
+    EntityOutputs.AddOutput(PLR_TEAMS[3].pushzone, "OnNumCappersChanged2", "mm_plr_logiccase_blu", "InValue", "", 0, -1);
 
     // Prevent SetSpeedForwardModifier for final ramp from triggering more than once
-    // This fixes a weird bug where the cart humps the second-to-last path_track during rollback.
-
     EntityOutputs.RemoveOutput(MM_GetEntByName("ssplr_red_pathA_start84"), "OnPass", "plr_red_train", "SetSpeedForwardModifier", "0.04");
     EntityOutputs.RemoveOutput(MM_GetEntByName("ssplr_red_pathA_start82"), "OnPass", "plr_red_train", "SetSpeedForwardModifier", "0.04");
     EntityOutputs.RemoveOutput(MM_GetEntByName("ssplr_blu_pathA_start86"), "OnPass", "plr_blu_train", "SetSpeedForwardModifier", "0.04");
@@ -56,18 +41,15 @@ function OnGameEvent_teamplay_round_start(params) {
     // Move the BLU team game_texts to different channel so RED and BLU can both be on screen
     EntFire("text_hack_blu*", "AddOutput", "channel 4", 0, null);
 
-    // Rollzones RED
-    AddRollbackZone("ssplr_red_pathA_start64", "ssplr_red_pathA_start65", "ssplr_red_pathA_start83", "Red");
-    AddRollbackZone("ssplr_red_pathA_start74", "ssplr_red_pathA_start75", "ssplr_red_pathA_start73", "Red");
-    AddRollbackZone("ssplr_red_pathA_start82", "red_path_15", "ssplr_red_pathA_start81", "Red");
-
-    // Rollzones BLU
-    AddRollbackZone("ssplr_blu_pathA_start68", "ssplr_blu_pathA_start69", "ssplr_blu_pathA_start87", "Blu");
-    AddRollbackZone("ssplr_blu_pathA_start78", "ssplr_blu_pathA_start79", "ssplr_blu_pathA_start77", "Blu");
-    AddRollbackZone("ssplr_blu_pathA_start85", "blu_path_15", "ssplr_blu_pathA_start84", "Blu");
+    // Rollzones
+    PLR_AddRollbackZone(2, "ssplr_red_pathA_start64", "ssplr_red_pathA_start65", "ssplr_red_pathA_start83");
+    PLR_AddRollbackZone(2, "ssplr_red_pathA_start74", "ssplr_red_pathA_start75", "ssplr_red_pathA_start73");
+    PLR_AddRollbackZone(2, "ssplr_red_pathA_start82", "red_path_15", "ssplr_red_pathA_start81");
+    PLR_AddRollbackZone(3, "ssplr_blu_pathA_start68", "ssplr_blu_pathA_start69", "ssplr_blu_pathA_start87");
+    PLR_AddRollbackZone(3, "ssplr_blu_pathA_start78", "ssplr_blu_pathA_start79", "ssplr_blu_pathA_start77");
+    PLR_AddRollbackZone(3, "ssplr_blu_pathA_start85", "blu_path_15", "ssplr_blu_pathA_start84");
 
     // Crossing logic replacement
-
     foreach(entName in [
         "ssplr_red_crossover1_branch"
         "ssplr_red_crossover1_relay"
@@ -85,16 +67,25 @@ function OnGameEvent_teamplay_round_start(params) {
         MM_GetEntByName(entName).Kill();
     }
 
-    AddCrossing("ssplr_red_crossover1_start", "ssplr_red_crossover1_end", "ssplr_blu_crossover1_start", "ssplr_blu_crossover1_end", 1);
-    AddCrossing("ssplr_red_pathA_start55", "ssplr_red_pathA_start56", "ssplr_blu_pathA_start59", "ssplr_blu_pathA_start60", 2);
-    AddCrossing("ssplr_red_pathA_start80", "ssplr_red_pathA_start81", "ssplr_blu_pathA_start83", "ssplr_blu_pathA_start84", 3);
+    AddCrossing([
+        ["ssplr_red_crossover1_start", "ssplr_red_crossover1_end", 2],
+        ["ssplr_blu_crossover1_start", "ssplr_blu_crossover1_end", 3]
+    ]);
+    AddCrossing([
+        ["ssplr_red_pathA_start55", "ssplr_red_pathA_start56", 2],
+        ["ssplr_blu_pathA_start59", "ssplr_blu_pathA_start60", 3]
+    ]);
+    AddCrossing([
+        ["ssplr_red_pathA_start80", "ssplr_red_pathA_start81", 2],
+        ["ssplr_blu_pathA_start83", "ssplr_blu_pathA_start84", 3]
+    ]);
 
     // team_train_watcher is no longer in charge.
-    NetProps.SetPropBool(RED_WATCHER, "m_bHandleTrainMovement", false);
-    NetProps.SetPropBool(BLU_WATCHER, "m_bHandleTrainMovement", false);
+    NetProps.SetPropBool(PLR_TEAMS[2].watcher, "m_bHandleTrainMovement", false);
+    NetProps.SetPropBool(PLR_TEAMS[3].watcher, "m_bHandleTrainMovement", false);
 
-    EntityOutputs.AddOutput(RED_PUSHZONE, "OnNumCappersChanged2", "plr_red_watcher", "SetNumTrainCappers", "", 0, -1);
-    EntityOutputs.AddOutput(BLU_PUSHZONE, "OnNumCappersChanged2", "plr_blu_watcher", "SetNumTrainCappers", "", 0, -1);
+    EntityOutputs.AddOutput(PLR_TEAMS[2].pushzone, "OnNumCappersChanged2", "plr_red_watcher", "SetNumTrainCappers", "", 0, -1);
+    EntityOutputs.AddOutput(PLR_TEAMS[3].pushzone, "OnNumCappersChanged2", "plr_blu_watcher", "SetNumTrainCappers", "", 0, -1);
 
     // Timer logic replacement
     EntityOutputs.RemoveOutput(PLR_TIMER, "OnSetupFinished", PLR_TIMER_NAME, "Disable", "");
@@ -102,8 +93,8 @@ function OnGameEvent_teamplay_round_start(params) {
     EntityOutputs.AddOutput(PLR_TIMER, "OnFinished", "!self", "RunScriptCode", "StartOvertime()", 0, -1);
 
     // Add thinks to carts
-    CreateCartAutoUpdater(RED_TRAIN, 2);
-    CreateCartAutoUpdater(BLU_TRAIN, 3);
+    PLR_CreateCartAutoUpdater(2, PLR_TEAMS[2].train);
+    PLR_CreateCartAutoUpdater(3, PLR_TEAMS[3].train);
 }
 
 __CollectGameEventCallbacks(this);

--- a/mega_mod/mapmods/plr_hacksaw_event.nut
+++ b/mega_mod/mapmods/plr_hacksaw_event.nut
@@ -41,11 +41,6 @@ function OnGameEvent_teamplay_round_start(params) {
     // Move the BLU team game_texts to different channel so RED and BLU can both be on screen
     EntFire("text_hack_blu*", "AddOutput", "channel 4", 0, null);
 
-    // Clean up unnecessary entities
-    for (local ent = null; ent = Entities.FindByClassname(ent, "func_rotating");) {
-        ent.Kill();
-    }
-
     // Rollzones
     PLR_AddRollbackZone(2, "ssplr_red_pathA_start64", "ssplr_red_pathA_start65", "ssplr_red_pathA_start83");
     PLR_AddRollbackZone(2, "ssplr_red_pathA_start74", "ssplr_red_pathA_start75", "ssplr_red_pathA_start73");

--- a/mega_mod/mapmods/plr_hacksaw_event.nut
+++ b/mega_mod/mapmods/plr_hacksaw_event.nut
@@ -72,15 +72,15 @@ function OnGameEvent_teamplay_round_start(params) {
         MM_GetEntByName(entName).Kill();
     }
 
-    AddCrossing([
+    PLR_AddCrossing([
         ["ssplr_red_crossover1_start", "ssplr_red_crossover1_end", 2],
         ["ssplr_blu_crossover1_start", "ssplr_blu_crossover1_end", 3]
     ]);
-    AddCrossing([
+    PLR_AddCrossing([
         ["ssplr_red_pathA_start55", "ssplr_red_pathA_start56", 2],
         ["ssplr_blu_pathA_start59", "ssplr_blu_pathA_start60", 3]
     ]);
-    AddCrossing([
+    PLR_AddCrossing([
         ["ssplr_red_pathA_start80", "ssplr_red_pathA_start81", 2],
         ["ssplr_blu_pathA_start83", "ssplr_blu_pathA_start84", 3]
     ]);
@@ -94,11 +94,11 @@ function OnGameEvent_teamplay_round_start(params) {
 
     // Timer logic replacement
     EntityOutputs.RemoveOutput(PLR_TIMER, "OnSetupFinished", PLR_TIMER_NAME, "Disable", "");
-    EntityOutputs.AddOutput(PLR_TIMER, "OnSetupFinished", "!self", "SetTime", GetRoundTimeString(), 0, -1);
-    EntityOutputs.AddOutput(PLR_TIMER, "OnFinished", "!self", "RunScriptCode", "StartOvertime()", 0, -1);
+    EntityOutputs.AddOutput(PLR_TIMER, "OnSetupFinished", "!self", "SetTime", PLR_GetRoundTimeString(), 0, -1);
+    EntityOutputs.AddOutput(PLR_TIMER, "OnFinished", "!self", "RunScriptCode", "PLR_StartOvertime()", 0, -1);
 
-    EntityOutputs.AddOutput(MM_GetEntByName("relay_red_capture_cart"), "OnTrigger", "!self", "RunScriptCode", "ForceStopCarts()", 0, -1);
-    EntityOutputs.AddOutput(MM_GetEntByName("relay_blu_capture_cart"), "OnTrigger", "!self", "RunScriptCode", "ForceStopCarts()", 0, -1);
+    EntityOutputs.AddOutput(MM_GetEntByName("relay_red_capture_cart"), "OnTrigger", "!self", "RunScriptCode", "PLR_ForceStopCarts()", 0, -1);
+    EntityOutputs.AddOutput(MM_GetEntByName("relay_blu_capture_cart"), "OnTrigger", "!self", "RunScriptCode", "PLR_ForceStopCarts()", 0, -1);
 
     // Add thinks to carts
     PLR_CreateCartAutoUpdater(2, PLR_TEAMS[2].train);

--- a/mega_mod/mapmods/plr_hacksaw_event.nut
+++ b/mega_mod/mapmods/plr_hacksaw_event.nut
@@ -8,40 +8,25 @@ function OnGameEvent_teamplay_round_start(params) {
     ::PLR_TIMER_NAME <- "ssplr_timer";
     ::PLR_TIMER = MM_GetEntByName(PLR_TIMER_NAME);
 
-    ::RED_CARTSPARKS_ARRAY <- MM_GetEntArrayByName("ssplr_red_cartsparks");
-    ::BLU_CARTSPARKS_ARRAY <- MM_GetEntArrayByName("ssplr_blu_cartsparks");
+    PLR_TEAMS[2].cartsparks = MM_GetEntArrayByName("ssplr_red_cartsparks");
+    PLR_TEAMS[3].cartsparks = MM_GetEntArrayByName("ssplr_blu_cartsparks");
 
-    ::RED_PUSHZONE <- MM_GetEntByName("plr_red_pushzone");
-    ::BLU_PUSHZONE <- MM_GetEntByName("plr_blu_pushzone");
+    PLR_TEAMS[2].pushzone = MM_GetEntByName("plr_red_pushzone");
+    PLR_TEAMS[3].pushzone = MM_GetEntByName("plr_blu_pushzone");
 
-    ::RED_TRAIN <- MM_GetEntByName("plr_red_train");
-    ::BLU_TRAIN <- MM_GetEntByName("plr_blu_train");
+    PLR_TEAMS[2].train = MM_GetEntByName("plr_red_train");
+    PLR_TEAMS[3].train = MM_GetEntByName("plr_blu_train");
 
-    ::RED_LOGICCASE <- CreateLogicCase("mm_plr_logiccase_red", "Red");
-    ::BLU_LOGICCASE <- CreateLogicCase("mm_plr_logiccase_blu", "Blu");
+    PLR_TEAMS[2].logiccase = PLR_CreateLogicCase(2, "mm_plr_logiccase_red");
+    PLR_TEAMS[3].logiccase = PLR_CreateLogicCase(3, "mm_plr_logiccase_blu");
 
-    ::RED_WATCHER <- MM_GetEntByName("plr_red_watcher");
-    ::BLU_WATCHER <- MM_GetEntByName("plr_blu_watcher");
+    PLR_TEAMS[2].watcher = MM_GetEntByName("plr_red_watcher");
+    PLR_TEAMS[3].watcher = MM_GetEntByName("plr_blu_watcher");
 
-    EntityOutputs.AddOutput(RED_PUSHZONE, "OnNumCappersChanged2", "mm_plr_logiccase_red", "InValue", "", 0, -1);
-    EntityOutputs.AddOutput(BLU_PUSHZONE, "OnNumCappersChanged2", "mm_plr_logiccase_blu", "InValue", "", 0, -1);
-
-    // Some rollback zones are improperly marked. This removes the uphill spawnflag from the offending path_track entities
-    // TODO: Find a way to update team_train_watcher entities to reflect these changes
-    // foreach(entName in [
-    //     "ssplr_red_pathA_start83",
-    //     "ssplr_red_pathA_start73",
-    //     "ssplr_red_pathA_start79",
-    //     "ssplr_blu_pathA_start87",
-    //     "ssplr_blu_pathA_start77",
-    //     "ssplr_blu_pathA_start89"
-    // ]) {
-    //     EntFireByHandle(MM_GetEntByName(entName), "AddOutput", "spawnflags 0", 0, null, null);
-    // }
+    EntityOutputs.AddOutput(PLR_TEAMS[2].pushzone, "OnNumCappersChanged2", "mm_plr_logiccase_red", "InValue", "", 0, -1);
+    EntityOutputs.AddOutput(PLR_TEAMS[3].pushzone, "OnNumCappersChanged2", "mm_plr_logiccase_blu", "InValue", "", 0, -1);
 
     // Prevent SetSpeedForwardModifier for final ramp from triggering more than once
-    // This fixes a weird bug where the cart humps the second-to-last path_track during rollback.
-
     EntityOutputs.RemoveOutput(MM_GetEntByName("ssplr_red_pathA_start84"), "OnPass", "plr_red_train", "SetSpeedForwardModifier", "0.04");
     EntityOutputs.RemoveOutput(MM_GetEntByName("ssplr_red_pathA_start82"), "OnPass", "plr_red_train", "SetSpeedForwardModifier", "0.04");
     EntityOutputs.RemoveOutput(MM_GetEntByName("ssplr_blu_pathA_start86"), "OnPass", "plr_blu_train", "SetSpeedForwardModifier", "0.04");
@@ -61,18 +46,15 @@ function OnGameEvent_teamplay_round_start(params) {
         ent.Kill();
     }
 
-    // Rollzones RED
-    AddRollbackZone("ssplr_red_pathA_start64", "ssplr_red_pathA_start65", "ssplr_red_pathA_start83", "Red");
-    AddRollbackZone("ssplr_red_pathA_start74", "ssplr_red_pathA_start75", "ssplr_red_pathA_start73", "Red");
-    AddRollbackZone("ssplr_red_pathA_start82", "red_path_15", "ssplr_red_pathA_start81", "Red");
-
-    // Rollzones BLU
-    AddRollbackZone("ssplr_blu_pathA_start68", "ssplr_blu_pathA_start69", "ssplr_blu_pathA_start87", "Blu");
-    AddRollbackZone("ssplr_blu_pathA_start78", "ssplr_blu_pathA_start79", "ssplr_blu_pathA_start77", "Blu");
-    AddRollbackZone("ssplr_blu_pathA_start85", "blu_path_15", "ssplr_blu_pathA_start84", "Blu");
+    // Rollzones
+    PLR_AddRollbackZone(2, "ssplr_red_pathA_start64", "ssplr_red_pathA_start65", "ssplr_red_pathA_start83");
+    PLR_AddRollbackZone(2, "ssplr_red_pathA_start74", "ssplr_red_pathA_start75", "ssplr_red_pathA_start73");
+    PLR_AddRollbackZone(2, "ssplr_red_pathA_start82", "red_path_15", "ssplr_red_pathA_start81");
+    PLR_AddRollbackZone(3, "ssplr_blu_pathA_start68", "ssplr_blu_pathA_start69", "ssplr_blu_pathA_start87");
+    PLR_AddRollbackZone(3, "ssplr_blu_pathA_start78", "ssplr_blu_pathA_start79", "ssplr_blu_pathA_start77");
+    PLR_AddRollbackZone(3, "ssplr_blu_pathA_start85", "blu_path_15", "ssplr_blu_pathA_start84");
 
     // Crossing logic replacement
-
     foreach(entName in [
         "ssplr_red_crossover1_branch"
         "ssplr_red_crossover1_relay"
@@ -90,16 +72,25 @@ function OnGameEvent_teamplay_round_start(params) {
         MM_GetEntByName(entName).Kill();
     }
 
-    AddCrossing("ssplr_red_crossover1_start", "ssplr_red_crossover1_end", "ssplr_blu_crossover1_start", "ssplr_blu_crossover1_end", 1);
-    AddCrossing("ssplr_red_pathA_start55", "ssplr_red_pathA_start56", "ssplr_blu_pathA_start59", "ssplr_blu_pathA_start60", 2);
-    AddCrossing("ssplr_red_pathA_start80", "ssplr_red_pathA_start81", "ssplr_blu_pathA_start83", "ssplr_blu_pathA_start84", 3);
+    AddCrossing([
+        ["ssplr_red_crossover1_start", "ssplr_red_crossover1_end", 2],
+        ["ssplr_blu_crossover1_start", "ssplr_blu_crossover1_end", 3]
+    ]);
+    AddCrossing([
+        ["ssplr_red_pathA_start55", "ssplr_red_pathA_start56", 2],
+        ["ssplr_blu_pathA_start59", "ssplr_blu_pathA_start60", 3]
+    ]);
+    AddCrossing([
+        ["ssplr_red_pathA_start80", "ssplr_red_pathA_start81", 2],
+        ["ssplr_blu_pathA_start83", "ssplr_blu_pathA_start84", 3]
+    ]);
 
     // team_train_watcher is no longer in charge.
-    NetProps.SetPropBool(RED_WATCHER, "m_bHandleTrainMovement", false);
-    NetProps.SetPropBool(BLU_WATCHER, "m_bHandleTrainMovement", false);
+    NetProps.SetPropBool(PLR_TEAMS[2].watcher, "m_bHandleTrainMovement", false);
+    NetProps.SetPropBool(PLR_TEAMS[3].watcher, "m_bHandleTrainMovement", false);
 
-    EntityOutputs.AddOutput(RED_PUSHZONE, "OnNumCappersChanged2", "plr_red_watcher", "SetNumTrainCappers", "", 0, -1);
-    EntityOutputs.AddOutput(BLU_PUSHZONE, "OnNumCappersChanged2", "plr_blu_watcher", "SetNumTrainCappers", "", 0, -1);
+    EntityOutputs.AddOutput(PLR_TEAMS[2].pushzone, "OnNumCappersChanged2", "plr_red_watcher", "SetNumTrainCappers", "", 0, -1);
+    EntityOutputs.AddOutput(PLR_TEAMS[3].pushzone, "OnNumCappersChanged2", "plr_blu_watcher", "SetNumTrainCappers", "", 0, -1);
 
     // Timer logic replacement
     EntityOutputs.RemoveOutput(PLR_TIMER, "OnSetupFinished", PLR_TIMER_NAME, "Disable", "");
@@ -110,8 +101,8 @@ function OnGameEvent_teamplay_round_start(params) {
     EntityOutputs.AddOutput(MM_GetEntByName("relay_blu_capture_cart"), "OnTrigger", "!self", "RunScriptCode", "ForceStopCarts()", 0, -1);
 
     // Add thinks to carts
-    CreateCartAutoUpdater(RED_TRAIN, 2);
-    CreateCartAutoUpdater(BLU_TRAIN, 3);
+    PLR_CreateCartAutoUpdater(2, PLR_TEAMS[2].train);
+    PLR_CreateCartAutoUpdater(3, PLR_TEAMS[3].train);
 }
 
 __CollectGameEventCallbacks(this);

--- a/mega_mod/mapmods/plr_hightower.nut
+++ b/mega_mod/mapmods/plr_hightower.nut
@@ -8,23 +8,23 @@ function OnGameEvent_teamplay_round_start(params) {
     ::PLR_TIMER_NAME <- "plr_timer";
     ::PLR_TIMER = MM_GetEntByName(PLR_TIMER_NAME);
 
-    ::RED_CARTSPARKS_ARRAY <- MM_GetEntArrayByName("plr_red_cartsparks");
-    ::BLU_CARTSPARKS_ARRAY <- MM_GetEntArrayByName("plr_blu_cartsparks");
+    PLR_TEAMS[2].cartsparks = MM_GetEntArrayByName("plr_red_cartsparks");
+    PLR_TEAMS[3].cartsparks = MM_GetEntArrayByName("plr_blu_cartsparks");
 
-    ::RED_FLASHINGLIGHT <- MM_GetEntByName("plr_red_flashinglight");
-    ::BLU_FLASHINGLIGHT <- MM_GetEntByName("plr_blu_flashinglight");
+    PLR_TEAMS[2].flashinglight = MM_GetEntByName("plr_red_flashinglight");
+    PLR_TEAMS[3].flashinglight = MM_GetEntByName("plr_blu_flashinglight");
 
-    ::RED_PUSHZONE <- MM_GetEntByName("plr_red_pushzone");
-    ::BLU_PUSHZONE <- MM_GetEntByName("plr_blu_pushzone");
+    PLR_TEAMS[2].pushzone = MM_GetEntByName("plr_red_pushzone");
+    PLR_TEAMS[3].pushzone = MM_GetEntByName("plr_blu_pushzone");
 
-    ::RED_TRAIN <- MM_GetEntByName("plr_red_train");
-    ::BLU_TRAIN <- MM_GetEntByName("plr_blu_train");
+    PLR_TEAMS[2].train = MM_GetEntByName("plr_red_train");
+    PLR_TEAMS[3].train = MM_GetEntByName("plr_blu_train");
 
-    ::RED_ELV <- null;
-    ::BLU_ELV <- null;
+    PLR_TEAMS[2].custom.elv = null;
+    PLR_TEAMS[3].custom.elv = null;
 
-    ::RED_WATCHER <- MM_GetEntByName("plr_red_watcherC");
-    ::BLU_WATCHER <- MM_GetEntByName("plr_blu_watcherC");
+    PLR_TEAMS[2].watcher = MM_GetEntByName("plr_red_watcherC");
+    PLR_TEAMS[3].watcher = MM_GetEntByName("plr_blu_watcherC");
 
     // Cart control logic replacement
     MM_GetEntByName("template_elv_case_red").Kill();
@@ -32,18 +32,18 @@ function OnGameEvent_teamplay_round_start(params) {
     MM_GetEntByName("plr_red_pushingcase").Kill();
     MM_GetEntByName("plr_blu_pushingcase").Kill();
 
-    ::RED_LOGICCASE <- CreateLogicCase("mm_plr_logiccase_red", "Red");
-    ::BLU_LOGICCASE <- CreateLogicCase("mm_plr_logiccase_blu", "Blu");
+    PLR_TEAMS[2].logiccase = PLR_CreateLogicCase(2, "mm_plr_logiccase_red");
+    PLR_TEAMS[3].logiccase = PLR_CreateLogicCase(3, "mm_plr_logiccase_blu");
 
-    EntityOutputs.AddOutput(RED_PUSHZONE, "OnNumCappersChanged2", "mm_plr_logiccase_red", "InValue", "", 0, -1);
-    EntityOutputs.AddOutput(BLU_PUSHZONE, "OnNumCappersChanged2", "mm_plr_logiccase_blu", "InValue", "", 0, -1);
+    EntityOutputs.AddOutput(PLR_TEAMS[2].pushzone, "OnNumCappersChanged2", "mm_plr_logiccase_red", "InValue", "", 0, -1);
+    EntityOutputs.AddOutput(PLR_TEAMS[3].pushzone, "OnNumCappersChanged2", "mm_plr_logiccase_blu", "InValue", "", 0, -1);
 
     // First hills
-    AddRollbackZone("plr_red_pathC_mid_35", "plr_red_pathC_mid_38", "plr_red_pathC_mid_34", "Red");
-    AddRollbackZone("plr_blu_pathC_hillA38", "plr_blu_pathC_hillA22", "plr_blu_pathC_hillA19", "Blu");
+    PLR_AddRollbackZone(2, "plr_red_pathC_mid_35", "plr_red_pathC_mid_38", "plr_red_pathC_mid_34");
+    PLR_AddRollbackZone(3, "plr_blu_pathC_hillA38", "plr_blu_pathC_hillA22", "plr_blu_pathC_hillA19");
     // Elevators
-    AddRollbackZone("plr_red_pathC_hillA3", "plr_red_pathC_end_dummy", "plr_red_pathC_hillA2", "Red");
-    AddRollbackZone("plr_blu_pathC_hillA3", "plr_blu_pathC_end_dummy", "plr_blu_pathC_hillA2", "Blu");
+    PLR_AddRollbackZone(2, "plr_red_pathC_hillA3", "plr_red_pathC_end_dummy", "plr_red_pathC_hillA2");
+    PLR_AddRollbackZone(3, "plr_blu_pathC_hillA3", "plr_blu_pathC_end_dummy", "plr_blu_pathC_hillA2");
 
     // Crossover logic replacement
     MM_GetEntByName("plr_red_crossover1_branch").Kill();
@@ -51,22 +51,19 @@ function OnGameEvent_teamplay_round_start(params) {
     MM_GetEntByName("plr_blu_crossover1_branch").Kill();
     MM_GetEntByName("plr_blu_crossover1_relay").Kill();
 
-    AddCrossing(
-        "plr_red_crossover1_start",
-        "plr_red_crossover1_end",
-        "plr_blu_crossover1_start",
-        "plr_blu_crossover1_end",
-        1
-    );
+    AddCrossing([
+        ["plr_red_crossover1_start", "plr_red_crossover1_end", 2],
+        ["plr_blu_crossover1_start", "plr_blu_crossover1_end", 3]
+    ]);
 
     // Elevator logic replacement
     MM_GetEntByName("clamp_logic_case_red").Kill();
     MM_GetEntByName("clamp_logic_case").Kill();
 
-    EntityOutputs.AddOutput(MM_GetEntByName("clamp_red_positioncart_relay_begin"), "OnTrigger", "!self", "RunScriptCode", "BlockRedCart(true)", 0, -1);
-    EntityOutputs.AddOutput(MM_GetEntByName("clamp_blu_positioncart_relay_begin"), "OnTrigger", "!self", "RunScriptCode", "BlockBluCart(true)", 0, -1);
-    EntityOutputs.AddOutput(MM_GetEntByName("clamp_red_positioncart_relay_end"), "OnTrigger", "!self", "RunScriptCode", "SwitchToElevatorRed()", 0.95, -1);
-    EntityOutputs.AddOutput(MM_GetEntByName("clamp_blu_positioncart_relay_end"), "OnTrigger", "!self", "RunScriptCode", "SwitchToElevatorBlu()", 0.95, -1);
+    EntityOutputs.AddOutput(MM_GetEntByName("clamp_red_positioncart_relay_begin"), "OnTrigger", "!self", "RunScriptCode", "PLR_BlockCart(2, true)", 0, -1);
+    EntityOutputs.AddOutput(MM_GetEntByName("clamp_blu_positioncart_relay_begin"), "OnTrigger", "!self", "RunScriptCode", "PLR_BlockCart(3, true)", 0, -1);
+    EntityOutputs.AddOutput(MM_GetEntByName("clamp_red_positioncart_relay_end"), "OnTrigger", "!self", "RunScriptCode", "SwitchToElevator(2)", 0.95, -1);
+    EntityOutputs.AddOutput(MM_GetEntByName("clamp_blu_positioncart_relay_end"), "OnTrigger", "!self", "RunScriptCode", "SwitchToElevator(3)", 0.95, -1);
 
     // Timer logic replacement
     EntityOutputs.RemoveOutput(PLR_TIMER, "OnSetupFinished", PLR_TIMER_NAME, "Disable", "");
@@ -74,8 +71,8 @@ function OnGameEvent_teamplay_round_start(params) {
     EntityOutputs.AddOutput(PLR_TIMER, "OnFinished", "!self", "RunScriptCode", "StartOvertime()", 0, -1);
 
     // Add thinks to carts
-    CreateCartAutoUpdater(RED_TRAIN, 2);
-    CreateCartAutoUpdater(BLU_TRAIN, 3);
+    PLR_CreateCartAutoUpdater(2, PLR_TEAMS[2].train);
+    PLR_CreateCartAutoUpdater(3, PLR_TEAMS[3].train);
 }
 
 ::StartOvertimeBase <- StartOvertime;
@@ -91,155 +88,70 @@ function StartOvertime() {
     StartOvertimeBase();
 }
 
-::AdvanceRedBase <- AdvanceRed;
-::StopRedBase <- StopRed;
-::TriggerRollbackRedBase <- TriggerRollbackRed;
-::AdvanceBluBase <- AdvanceBlu;
-::StopBluBase <- StopBlu;
-::TriggerRollbackBluBase <- TriggerRollbackBlu;
+// Override PLR_Advance/PLR_Stop/PLR_TriggerRollback to also control elevator
+::PLR_Advance_Base <- PLR_Advance;
+::PLR_Stop_Base <- PLR_Stop;
+::PLR_TriggerRollback_Base <- PLR_TriggerRollback;
 
-function AdvanceRed(speed, dynamic = true) {
-    if (RED_ELV) dynamic = false;
-    AdvanceRedBase(speed, dynamic);
-    if(RED_ELV) {
-        EntFireByHandle(RED_ELV, "SetSpeedForwardModifier", "0.25", 0, null, null);
-        EntFireByHandle(RED_ELV, "SetSpeedDirAccel", "" + speed, 0, null, null);
+function PLR_Advance(team, baseSpeed, dynamic = true) {
+    local t = PLR_TEAMS[team];
+    if (t.custom.elv) dynamic = false;
+    PLR_Advance_Base(team, baseSpeed, dynamic);
+    if(t.custom.elv) {
+        EntFireByHandle(t.custom.elv, "SetSpeedForwardModifier", "0.25", 0, null, null);
+        EntFireByHandle(t.custom.elv, "SetSpeedDirAccel", "" + baseSpeed, 0, null, null);
     }
 }
 
-function StopRed() {
-    StopRedBase();
-    if(RED_ELV) {
-        EntFireByHandle(RED_ELV, "SetSpeedForwardModifier", "0.25", 0, null, null);
-        EntFireByHandle(RED_ELV, "SetSpeedDirAccel", "0.0", 0, null, null);
+function PLR_Stop(team) {
+    local t = PLR_TEAMS[team];
+    PLR_Stop_Base(team);
+    if(t.custom.elv) {
+        EntFireByHandle(t.custom.elv, "SetSpeedForwardModifier", "0.25", 0, null, null);
+        EntFireByHandle(t.custom.elv, "SetSpeedDirAccel", "0.0", 0, null, null);
 
         // Stop sound if elevator is completely stopped.
-        local currentSpeed = NetProps.GetPropFloat(RED_ELV, "m_flSpeed");
-        if (currentSpeed == 0) EntFireByHandle(RED_ELV, "Stop", "", 0, null, null);
+        local currentSpeed = NetProps.GetPropFloat(t.custom.elv, "m_flSpeed");
+        if (currentSpeed == 0) EntFireByHandle(t.custom.elv, "Stop", "", 0, null, null);
     }
 }
 
-function TriggerRollbackRed() {
-    TriggerRollbackRedBase();
-    if(RED_ELV) {
-        EntFireByHandle(RED_ELV, "SetSpeedForwardModifier", "0.25", 0, null, null);
-        EntFireByHandle(RED_ELV, "SetSpeedDirAccel", "" + ROLLBACK_SPEED_RED, 0, null, null);
+function PLR_TriggerRollback(team, multiplier = 1.0) {
+    local t = PLR_TEAMS[team];
+    PLR_TriggerRollback_Base(team, multiplier);
+    if(t.custom.elv) {
+        EntFireByHandle(t.custom.elv, "SetSpeedForwardModifier", "0.25", 0, null, null);
+        EntFireByHandle(t.custom.elv, "SetSpeedDirAccel", "" + (t.rollbackSpeed * multiplier), 0, null, null);
     }
 }
-
-function AdvanceBlu(speed, dynamic = true) {
-    if (BLU_ELV) dynamic = false;
-    AdvanceBluBase(speed, dynamic);
-    if(BLU_ELV) {
-        EntFireByHandle(BLU_ELV, "SetSpeedForwardModifier", "0.25", 0, null, null);
-        EntFireByHandle(BLU_ELV, "SetSpeedDirAccel", "" + speed, 0, null, null);
-    }
-}
-
-function StopBlu() {
-    StopBluBase();
-    if(BLU_ELV) {
-        EntFireByHandle(BLU_ELV, "SetSpeedForwardModifier", "0.25", 0, null, null);
-        EntFireByHandle(BLU_ELV, "SetSpeedDirAccel", "0.0", 0, null, null);
-
-        // Stop sound if elevator is completely stopped.
-        local currentSpeed = NetProps.GetPropFloat(BLU_ELV, "m_flSpeed");
-        if (currentSpeed == 0) EntFireByHandle(BLU_ELV, "Stop", "", 0, null, null);
-    }
-}
-
-function TriggerRollbackBlu() {
-    TriggerRollbackBluBase();
-    if(BLU_ELV) {
-        EntFireByHandle(BLU_ELV, "SetSpeedForwardModifier", "0.25", 0, null, null);
-        EntFireByHandle(BLU_ELV, "SetSpeedDirAccel", "" + ROLLBACK_SPEED_BLU, 0, null, null);
-    }
-}
-
 
 // When the cart goes on the elevator, trigger necessary logic.
 // Also disables rollback, otherwise it becomes impossible to maintain sync
 // between the two func_tracktrains.
-function SwitchToElevatorRed() {
-    ::RED_ELV <- MM_GetEntByName("clamp_red");
-    ::RED_PUSHZONE <- MM_GetEntByName("plr_red_pushzone_elv");
-    ::RED_CARTSPARKS_ARRAY <- MM_GetEntArrayByName("plr_red_elevatorsparks");
+function SwitchToElevator(team) {
+    local t = PLR_TEAMS[team];
+    local otherTeam = team == 2 ? 3 : 2;
+    local otherT = PLR_TEAMS[otherTeam];
+
+    if(team == 2) {
+        t.custom.elv = MM_GetEntByName("clamp_red");
+        t.pushzone = MM_GetEntByName("plr_red_pushzone_elv");
+        t.cartsparks = MM_GetEntArrayByName("plr_red_elevatorsparks");
+        EntFireByHandle(t.train, "TeleportToPathTrack", "plr_red_pathC_hillA3", 0, null, null);
+        EntityOutputs.AddOutput(t.pushzone, "OnNumCappersChanged2", "mm_plr_logiccase_red", "InValue", "", 0, -1);
+    } else {
+        t.custom.elv = MM_GetEntByName("clamp_blue");
+        t.pushzone = MM_GetEntByName("plr_blu_pushzone_elv");
+        t.cartsparks = MM_GetEntArrayByName("plr_blu_elevatorsparks");
+        EntFireByHandle(t.train, "TeleportToPathTrack", "plr_blu_pathC_hillA3", 0, null, null);
+        EntityOutputs.AddOutput(t.pushzone, "OnNumCappersChanged2", "mm_plr_logiccase_blu", "InValue", "", 0, -1);
+    }
 
     DisableOvertimeRollback();
 
-    EntFireByHandle(RED_ELV, "SetSpeedForwardModifier", "0.25", 0, null, null);
-    EntFireByHandle(RED_TRAIN, "TeleportToPathTrack", "plr_red_pathC_hillA3", 0, null, null);
-    EntityOutputs.AddOutput(RED_PUSHZONE, "OnNumCappersChanged2", "mm_plr_logiccase_red", "InValue", "", 0, -1);
+    EntFireByHandle(t.custom.elv, "SetSpeedForwardModifier", "0.25", 0, null, null);
 
-    ::UpdateRedCart <- UpdateRedElevator;
-
-    BlockRedCart(false);
-}
-
-function SwitchToElevatorBlu() {
-    ::BLU_ELV <- MM_GetEntByName("clamp_blue");
-    ::BLU_PUSHZONE <- MM_GetEntByName("plr_blu_pushzone_elv");
-    ::BLU_CARTSPARKS_ARRAY <- MM_GetEntArrayByName("plr_blu_elevatorsparks");
-
-    DisableOvertimeRollback();
-
-    EntFireByHandle(BLU_ELV, "SetSpeedForwardModifier", "0.25", 0, null, null);
-    EntFireByHandle(BLU_TRAIN, "TeleportToPathTrack", "plr_blu_pathC_hillA3", 0, null, null);
-    EntityOutputs.AddOutput(BLU_PUSHZONE, "OnNumCappersChanged2", "mm_plr_logiccase_blu", "InValue", "", 0, -1);
-
-    ::UpdateBluCart <- UpdateBluElevator;
-
-    BlockBluCart(false);
-}
-
-function UpdateRedElevator(caseNumber) {
-    ::CASE_RED = caseNumber;
-
-    if(BLOCK_RED) return;
-
-    if(CASE_RED >= 1) {
-        AdvanceRed(TIMES_2_SPEED_RED);
-    } else if (CASE_RED == -1) {
-        StopRed();
-    }
-
-    if(CASE_RED == 0) {
-        if(CASE_BLU == 0 && OVERTIME_ACTIVE) {
-            AdvanceRed(OVERTIME_SPEED_RED);
-            if(!BLOCK_BLU) AdvanceBlu(OVERTIME_SPEED_BLU);
-        } else if (!OVERTIME_ACTIVE && RED_ROLLSTATE == -1) {
-            TriggerRollbackRed();
-        } else {
-            StopRed();
-        }
-    } else if (OVERTIME_ACTIVE && CASE_BLU == 0) {
-        UpdateBluCart(0);
-    }
-}
-
-function UpdateBluElevator(caseNumber) {
-    ::CASE_BLU = caseNumber;
-
-    if(BLOCK_BLU) return;
-
-    if(CASE_BLU >= 1) {
-        AdvanceBlu(TIMES_2_SPEED_BLU);
-    } else if (CASE_BLU == -1) {
-        StopBlu();
-    }
-
-    if(CASE_BLU == 0) {
-        if(CASE_RED == 0 && OVERTIME_ACTIVE) {
-            AdvanceBlu(OVERTIME_SPEED_BLU);
-            if(!BLOCK_RED) AdvanceRed(OVERTIME_SPEED_RED);
-        } else if (!OVERTIME_ACTIVE && BLU_ROLLSTATE == -1) {
-            TriggerRollbackBlu();
-        } else {
-            StopBlu();
-        }
-    } else if (OVERTIME_ACTIVE && CASE_RED == 0) {
-        UpdateRedCart(0);
-    }
+    PLR_BlockCart(team, false);
 }
 
 __CollectGameEventCallbacks(this);

--- a/mega_mod/mapmods/plr_hightower.nut
+++ b/mega_mod/mapmods/plr_hightower.nut
@@ -20,8 +20,8 @@ function OnGameEvent_teamplay_round_start(params) {
     PLR_TEAMS[2].train = MM_GetEntByName("plr_red_train");
     PLR_TEAMS[3].train = MM_GetEntByName("plr_blu_train");
 
-    PLR_TEAMS[2].custom.elv = null;
-    PLR_TEAMS[3].custom.elv = null;
+    PLR_TEAMS[2].custom.elv <- null;
+    PLR_TEAMS[3].custom.elv <- null;
 
     PLR_TEAMS[2].watcher = MM_GetEntByName("plr_red_watcherC");
     PLR_TEAMS[3].watcher = MM_GetEntByName("plr_blu_watcherC");

--- a/mega_mod/mapmods/plr_hightower.nut
+++ b/mega_mod/mapmods/plr_hightower.nut
@@ -51,7 +51,7 @@ function OnGameEvent_teamplay_round_start(params) {
     MM_GetEntByName("plr_blu_crossover1_branch").Kill();
     MM_GetEntByName("plr_blu_crossover1_relay").Kill();
 
-    AddCrossing([
+    PLR_AddCrossing([
         ["plr_red_crossover1_start", "plr_red_crossover1_end", 2],
         ["plr_blu_crossover1_start", "plr_blu_crossover1_end", 3]
     ]);
@@ -67,17 +67,17 @@ function OnGameEvent_teamplay_round_start(params) {
 
     // Timer logic replacement
     EntityOutputs.RemoveOutput(PLR_TIMER, "OnSetupFinished", PLR_TIMER_NAME, "Disable", "");
-    EntityOutputs.AddOutput(PLR_TIMER, "OnSetupFinished", "!self", "SetTime", GetRoundTimeString(), 0, -1);
-    EntityOutputs.AddOutput(PLR_TIMER, "OnFinished", "!self", "RunScriptCode", "StartOvertime()", 0, -1);
+    EntityOutputs.AddOutput(PLR_TIMER, "OnSetupFinished", "!self", "SetTime", PLR_GetRoundTimeString(), 0, -1);
+    EntityOutputs.AddOutput(PLR_TIMER, "OnFinished", "!self", "RunScriptCode", "PLR_StartOvertime()", 0, -1);
 
     // Add thinks to carts
     PLR_CreateCartAutoUpdater(2, PLR_TEAMS[2].train);
     PLR_CreateCartAutoUpdater(3, PLR_TEAMS[3].train);
 }
 
-::StartOvertimeBase <- StartOvertime;
+::PLR_StartOvertimeBase <- PLR_StartOvertime;
 
-function StartOvertime() {
+function PLR_StartOvertime() {
     local redRollbackRelay = MM_GetEntByName("plr_red_rollback_relay");
     local bluRollbackRelay = MM_GetEntByName("plr_blu_rollback_relay");
 
@@ -85,7 +85,7 @@ function StartOvertime() {
     EntFireByHandle(redRollbackRelay, "Disable", "", 0, null, null);
     EntFireByHandle(bluRollbackRelay, "Disable", "", 0, null, null);
 
-    StartOvertimeBase();
+    PLR_StartOvertimeBase();
 }
 
 // Override PLR_Advance/PLR_Stop/PLR_TriggerRollback to also control elevator
@@ -147,7 +147,7 @@ function SwitchToElevator(team) {
         EntityOutputs.AddOutput(t.pushzone, "OnNumCappersChanged2", "mm_plr_logiccase_blu", "InValue", "", 0, -1);
     }
 
-    DisableOvertimeRollback();
+    PLR_DisableOvertimeRollback();
 
     EntFireByHandle(t.custom.elv, "SetSpeedForwardModifier", "0.25", 0, null, null);
 

--- a/mega_mod/mapmods/plr_hightower_event.nut
+++ b/mega_mod/mapmods/plr_hightower_event.nut
@@ -8,8 +8,8 @@ function OnGameEvent_teamplay_round_start(params) {
     ::PLR_TIMER = MM_GetEntByName(PLR_TIMER_NAME);
 
     // For opening sequence where carts roll out.
-    ::BLOCK_RED <- true;
-    ::BLOCK_BLU <- true;
+    PLR_TEAMS[2].blocked = true;
+    PLR_TEAMS[3].blocked = true;
 
     // Timer logic replacement
     EntityOutputs.RemoveOutput(PLR_TIMER, "OnSetupFinished", PLR_TIMER_NAME, "Disable", "");
@@ -21,23 +21,23 @@ function OnGameEvent_teamplay_round_start(params) {
 
 function MM_HighTowerEvent_DelayedStart() {
 
-    ::RED_CARTSPARKS_ARRAY <- MM_GetEntArrayByName("plr_red_cartsparks");
-    ::BLU_CARTSPARKS_ARRAY <- MM_GetEntArrayByName("plr_blu_cartsparks");
+    PLR_TEAMS[2].cartsparks = MM_GetEntArrayByName("plr_red_cartsparks");
+    PLR_TEAMS[3].cartsparks = MM_GetEntArrayByName("plr_blu_cartsparks");
 
-    ::RED_PUSHZONE <- MM_GetEntByName("plr_red_pushzone");
-    ::BLU_PUSHZONE <- MM_GetEntByName("plr_blu_pushzone");
+    PLR_TEAMS[2].pushzone = MM_GetEntByName("plr_red_pushzone");
+    PLR_TEAMS[3].pushzone = MM_GetEntByName("plr_blu_pushzone");
 
-    ::RED_TRAIN <- MM_GetEntByName("plr_red_train");
-    ::BLU_TRAIN <- MM_GetEntByName("plr_blu_train");
+    PLR_TEAMS[2].train = MM_GetEntByName("plr_red_train");
+    PLR_TEAMS[3].train = MM_GetEntByName("plr_blu_train");
 
-    ::RED_WATCHER <- MM_GetEntByName("plr_red_watcherC");
-    ::BLU_WATCHER <- MM_GetEntByName("plr_blu_watcherC");
+    PLR_TEAMS[2].watcher = MM_GetEntByName("plr_red_watcherC");
+    PLR_TEAMS[3].watcher = MM_GetEntByName("plr_blu_watcherC");
 
-    ::RED_ELV <- null;
-    ::BLU_ELV <- null;
+    PLR_TEAMS[2].custom.elv = null;
+    PLR_TEAMS[3].custom.elv = null;
 
-    ::BLOCK_RED <- false;
-    ::BLOCK_BLU <- false;
+    PLR_TEAMS[2].blocked = false;
+    PLR_TEAMS[3].blocked = false;
 
     // Cart control logic replacement
     MM_GetEntByName("template_elv_case_red").Kill();
@@ -45,15 +45,15 @@ function MM_HighTowerEvent_DelayedStart() {
     MM_GetEntByName("plr_red_pushingcase").Kill();
     MM_GetEntByName("plr_blu_pushingcase").Kill();
 
-    ::RED_LOGICCASE <- CreateLogicCase("mm_plr_logiccase_red", "Red");
-    ::BLU_LOGICCASE <- CreateLogicCase("mm_plr_logiccase_blu", "Blu");
+    PLR_TEAMS[2].logiccase = PLR_CreateLogicCase(2, "mm_plr_logiccase_red");
+    PLR_TEAMS[3].logiccase = PLR_CreateLogicCase(3, "mm_plr_logiccase_blu");
 
-    EntityOutputs.AddOutput(RED_PUSHZONE, "OnNumCappersChanged2", "mm_plr_logiccase_red", "InValue", "", 0, -1);
-    EntityOutputs.AddOutput(BLU_PUSHZONE, "OnNumCappersChanged2", "mm_plr_logiccase_blu", "InValue", "", 0, -1);
+    EntityOutputs.AddOutput(PLR_TEAMS[2].pushzone, "OnNumCappersChanged2", "mm_plr_logiccase_red", "InValue", "", 0, -1);
+    EntityOutputs.AddOutput(PLR_TEAMS[3].pushzone, "OnNumCappersChanged2", "mm_plr_logiccase_blu", "InValue", "", 0, -1);
 
     // Elevators
-    AddRollbackZone("plr_red_pathC_hillA3", "plr_red_pathC_hillA17", "plr_red_pathC_hillA2", "Red");
-    AddRollbackZone("plr_blu_pathC_hillA3", "plr_blu_pathC_hillA67", "plr_blu_pathC_hillA2", "Blu");
+    PLR_AddRollbackZone(2, "plr_red_pathC_hillA3", "plr_red_pathC_hillA17", "plr_red_pathC_hillA2");
+    PLR_AddRollbackZone(3, "plr_blu_pathC_hillA3", "plr_blu_pathC_hillA67", "plr_blu_pathC_hillA2");
 
     // Crossover logic replacement
     MM_GetEntByName("plr_red_crossover1_branch").Kill();
@@ -61,29 +61,26 @@ function MM_HighTowerEvent_DelayedStart() {
     MM_GetEntByName("plr_blu_crossover1_branch").Kill();
     MM_GetEntByName("plr_blu_crossover1_relay").Kill();
 
-    AddCrossing(
-        "plr_red_crossover1_start",
-        "plr_red_crossover1_end",
-        "plr_blu_crossover1_start",
-        "plr_blu_crossover1_end",
-        1
-    );
+    AddCrossing([
+        ["plr_red_crossover1_start", "plr_red_crossover1_end", 2],
+        ["plr_blu_crossover1_start", "plr_blu_crossover1_end", 3]
+    ]);
 
     // Elevator logic replacement
     MM_GetEntByName("clamp_logic_case_red").Kill();
     MM_GetEntByName("clamp_logic_case").Kill();
 
-    EntityOutputs.AddOutput(MM_GetEntByName("clamp_red_positioncart_relay_begin"), "OnTrigger", "!self", "RunScriptCode", "BlockRedCart(true)", 0, -1);
-    EntityOutputs.AddOutput(MM_GetEntByName("clamp_blu_positioncart_relay_begin"), "OnTrigger", "!self", "RunScriptCode", "BlockBluCart(true)", 0, -1);
-    EntityOutputs.AddOutput(MM_GetEntByName("clamp_red_positioncart_relay_end"), "OnTrigger", "!self", "RunScriptCode", "SwitchToElevatorRed()", 0.95, -1);
-    EntityOutputs.AddOutput(MM_GetEntByName("clamp_blu_positioncart_relay_end"), "OnTrigger", "!self", "RunScriptCode", "SwitchToElevatorBlu()", 0.95, -1);
+    EntityOutputs.AddOutput(MM_GetEntByName("clamp_red_positioncart_relay_begin"), "OnTrigger", "!self", "RunScriptCode", "PLR_BlockCart(2, true)", 0, -1);
+    EntityOutputs.AddOutput(MM_GetEntByName("clamp_blu_positioncart_relay_begin"), "OnTrigger", "!self", "RunScriptCode", "PLR_BlockCart(3, true)", 0, -1);
+    EntityOutputs.AddOutput(MM_GetEntByName("clamp_red_positioncart_relay_end"), "OnTrigger", "!self", "RunScriptCode", "SwitchToElevator(2)", 0.95, -1);
+    EntityOutputs.AddOutput(MM_GetEntByName("clamp_blu_positioncart_relay_end"), "OnTrigger", "!self", "RunScriptCode", "SwitchToElevator(3)", 0.95, -1);
 
     EntityOutputs.AddOutput(MM_GetEntByName("relay_red_capture_cart"), "OnTrigger", "!self", "RunScriptCode", "ForceStopCarts()", 0, -1);
     EntityOutputs.AddOutput(MM_GetEntByName("relay_blu_capture_cart"), "OnTrigger", "!self", "RunScriptCode", "ForceStopCarts()", 0, -1);
 
     // Add thinks to carts
-    CreateCartAutoUpdater(RED_TRAIN, 2);
-    CreateCartAutoUpdater(BLU_TRAIN, 3);
+    PLR_CreateCartAutoUpdater(2, PLR_TEAMS[2].train);
+    PLR_CreateCartAutoUpdater(3, PLR_TEAMS[3].train);
 }
 
 ::StartOvertimeBase <- StartOvertime;
@@ -103,155 +100,67 @@ function StartOvertime() {
     StartOvertimeBase();
 }
 
-::AdvanceRedBase <- AdvanceRed;
-::StopRedBase <- StopRed;
-::TriggerRollbackRedBase <- TriggerRollbackRed;
-::AdvanceBluBase <- AdvanceBlu;
-::StopBluBase <- StopBlu;
-::TriggerRollbackBluBase <- TriggerRollbackBlu;
+// Override PLR_Advance/PLR_Stop/PLR_TriggerRollback to also control elevator
+::PLR_Advance_Base <- PLR_Advance;
+::PLR_Stop_Base <- PLR_Stop;
+::PLR_TriggerRollback_Base <- PLR_TriggerRollback;
 
-function AdvanceRed(speed, dynamic = true) {
-    if (RED_ELV) dynamic = false;
-    AdvanceRedBase(speed, dynamic);
-    if(RED_ELV) {
-        EntFireByHandle(RED_ELV, "SetSpeedForwardModifier", "0.25", 0, null, null);
-        EntFireByHandle(RED_ELV, "SetSpeedDirAccel", "" + speed, 0, null, null);
+function PLR_Advance(team, baseSpeed, dynamic = true) {
+    local t = PLR_TEAMS[team];
+    if (t.custom.elv) dynamic = false;
+    PLR_Advance_Base(team, baseSpeed, dynamic);
+    if(t.custom.elv) {
+        EntFireByHandle(t.custom.elv, "SetSpeedForwardModifier", "0.25", 0, null, null);
+        EntFireByHandle(t.custom.elv, "SetSpeedDirAccel", "" + baseSpeed, 0, null, null);
     }
 }
 
-function StopRed() {
-    StopRedBase();
-    if(RED_ELV) {
-        EntFireByHandle(RED_ELV, "SetSpeedForwardModifier", "0.25", 0, null, null);
-        EntFireByHandle(RED_ELV, "SetSpeedDirAccel", "0.0", 0, null, null);
+function PLR_Stop(team) {
+    local t = PLR_TEAMS[team];
+    PLR_Stop_Base(team);
+    if(t.custom.elv) {
+        EntFireByHandle(t.custom.elv, "SetSpeedForwardModifier", "0.25", 0, null, null);
+        EntFireByHandle(t.custom.elv, "SetSpeedDirAccel", "0.0", 0, null, null);
 
-        // Stop sound if elevator is completely stopped.
-        local currentSpeed = NetProps.GetPropFloat(RED_ELV, "m_flSpeed");
-        if (currentSpeed == 0) EntFireByHandle(RED_ELV, "Stop", "", 0, null, null);
+        local currentSpeed = NetProps.GetPropFloat(t.custom.elv, "m_flSpeed");
+        if (currentSpeed == 0) EntFireByHandle(t.custom.elv, "Stop", "", 0, null, null);
     }
 }
 
-function TriggerRollbackRed() {
-    TriggerRollbackRedBase();
-    if(RED_ELV) {
-        EntFireByHandle(RED_ELV, "SetSpeedForwardModifier", "0.25", 0, null, null);
-        EntFireByHandle(RED_ELV, "SetSpeedDirAccel", "" + ROLLBACK_SPEED_RED, 0, null, null);
+function PLR_TriggerRollback(team, multiplier = 1.0) {
+    local t = PLR_TEAMS[team];
+    PLR_TriggerRollback_Base(team, multiplier);
+    if(t.custom.elv) {
+        EntFireByHandle(t.custom.elv, "SetSpeedForwardModifier", "0.25", 0, null, null);
+        EntFireByHandle(t.custom.elv, "SetSpeedDirAccel", "" + (t.rollbackSpeed * multiplier), 0, null, null);
     }
 }
-
-function AdvanceBlu(speed, dynamic = true) {
-    if (BLU_ELV) dynamic = false;
-    AdvanceBluBase(speed, dynamic);
-    if(BLU_ELV) {
-        EntFireByHandle(BLU_ELV, "SetSpeedForwardModifier", "0.25", 0, null, null);
-        EntFireByHandle(BLU_ELV, "SetSpeedDirAccel", "" + speed, 0, null, null);
-    }
-}
-
-function StopBlu() {
-    StopBluBase();
-    if(BLU_ELV) {
-        EntFireByHandle(BLU_ELV, "SetSpeedForwardModifier", "0.25", 0, null, null);
-        EntFireByHandle(BLU_ELV, "SetSpeedDirAccel", "0.0", 0, null, null);
-
-        // Stop sound if elevator is completely stopped.
-        local currentSpeed = NetProps.GetPropFloat(BLU_ELV, "m_flSpeed");
-        if (currentSpeed == 0) EntFireByHandle(BLU_ELV, "Stop", "", 0, null, null);
-    }
-}
-
-function TriggerRollbackBlu() {
-    TriggerRollbackBluBase();
-    if(BLU_ELV) {
-        EntFireByHandle(BLU_ELV, "SetSpeedForwardModifier", "0.25", 0, null, null);
-        EntFireByHandle(BLU_ELV, "SetSpeedDirAccel", "" + ROLLBACK_SPEED_BLU, 0, null, null);
-    }
-}
-
 
 // When the cart goes on the elevator, trigger necessary logic.
 // Also disables rollback, otherwise it becomes impossible to maintain sync
 // between the two func_tracktrains.
-function SwitchToElevatorRed() {
-    ::RED_ELV <- MM_GetEntByName("clamp_red");
-    ::RED_PUSHZONE <- MM_GetEntByName("plr_red_pushzone_elv");
-    ::RED_CARTSPARKS_ARRAY <- MM_GetEntArrayByName("plr_red_elevatorsparks");
+function SwitchToElevator(team) {
+    local t = PLR_TEAMS[team];
+
+    if(team == 2) {
+        t.custom.elv = MM_GetEntByName("clamp_red");
+        t.pushzone = MM_GetEntByName("plr_red_pushzone_elv");
+        t.cartsparks = MM_GetEntArrayByName("plr_red_elevatorsparks");
+        EntFireByHandle(t.train, "TeleportToPathTrack", "plr_red_pathC_hillA3", 0, null, null);
+        EntityOutputs.AddOutput(t.pushzone, "OnNumCappersChanged2", "mm_plr_logiccase_red", "InValue", "", 0, -1);
+    } else {
+        t.custom.elv = MM_GetEntByName("clamp_blue");
+        t.pushzone = MM_GetEntByName("plr_blu_pushzone_elv");
+        t.cartsparks = MM_GetEntArrayByName("plr_blu_elevatorsparks");
+        EntFireByHandle(t.train, "TeleportToPathTrack", "plr_blu_pathC_hillA3", 0, null, null);
+        EntityOutputs.AddOutput(t.pushzone, "OnNumCappersChanged2", "mm_plr_logiccase_blu", "InValue", "", 0, -1);
+    }
 
     DisableOvertimeRollback();
 
-    EntFireByHandle(RED_ELV, "SetSpeedForwardModifier", "0.25", 0, null, null);
-    EntFireByHandle(RED_TRAIN, "TeleportToPathTrack", "plr_red_pathC_hillA3", 0, null, null);
-    EntityOutputs.AddOutput(RED_PUSHZONE, "OnNumCappersChanged2", "mm_plr_logiccase_red", "InValue", "", 0, -1);
+    EntFireByHandle(t.custom.elv, "SetSpeedForwardModifier", "0.25", 0, null, null);
 
-    ::UpdateRedCart <- UpdateRedElevator;
-
-    BlockRedCart(false);
-}
-
-function SwitchToElevatorBlu() {
-    ::BLU_ELV <- MM_GetEntByName("clamp_blue");
-    ::BLU_PUSHZONE <- MM_GetEntByName("plr_blu_pushzone_elv");
-    ::BLU_CARTSPARKS_ARRAY <- MM_GetEntArrayByName("plr_blu_elevatorsparks");
-
-    DisableOvertimeRollback();
-
-    EntFireByHandle(BLU_ELV, "SetSpeedForwardModifier", "0.25", 0, null, null);
-    EntFireByHandle(BLU_TRAIN, "TeleportToPathTrack", "plr_blu_pathC_hillA3", 0, null, null);
-    EntityOutputs.AddOutput(BLU_PUSHZONE, "OnNumCappersChanged2", "mm_plr_logiccase_blu", "InValue", "", 0, -1);
-
-    ::UpdateBluCart <- UpdateBluElevator;
-
-    BlockBluCart(false);
-}
-
-function UpdateRedElevator(caseNumber) {
-    ::CASE_RED = caseNumber;
-
-    if(BLOCK_RED) return;
-
-    if(CASE_RED >= 1) {
-        AdvanceRed(TIMES_2_SPEED_RED);
-    } else if (CASE_RED == -1) {
-        StopRed();
-    }
-
-    if(CASE_RED == 0) {
-        if(CASE_BLU == 0 && OVERTIME_ACTIVE) {
-            AdvanceRed(OVERTIME_SPEED_RED);
-            if(!BLOCK_BLU) AdvanceBlu(OVERTIME_SPEED_BLU);
-        } else if (!OVERTIME_ACTIVE && RED_ROLLSTATE == -1) {
-            TriggerRollbackRed();
-        } else {
-            StopRed();
-        }
-    } else if (OVERTIME_ACTIVE && CASE_BLU == 0) {
-        UpdateBluCart(0);
-    }
-}
-
-function UpdateBluElevator(caseNumber) {
-    ::CASE_BLU = caseNumber;
-
-    if(BLOCK_BLU) return;
-
-    if(CASE_BLU >= 1) {
-        AdvanceBlu(TIMES_2_SPEED_BLU);
-    } else if (CASE_BLU == -1) {
-        StopBlu();
-    }
-
-    if(CASE_BLU == 0) {
-        if(CASE_RED == 0 && OVERTIME_ACTIVE) {
-            AdvanceBlu(OVERTIME_SPEED_BLU);
-            if(!BLOCK_RED) AdvanceRed(OVERTIME_SPEED_RED);
-        } else if (!OVERTIME_ACTIVE && BLU_ROLLSTATE == -1) {
-            TriggerRollbackBlu();
-        } else {
-            StopBlu();
-        }
-    } else if (OVERTIME_ACTIVE && CASE_RED == 0) {
-        UpdateRedCart(0);
-    }
+    PLR_BlockCart(team, false);
 }
 
 __CollectGameEventCallbacks(this);

--- a/mega_mod/mapmods/plr_hightower_event.nut
+++ b/mega_mod/mapmods/plr_hightower_event.nut
@@ -13,8 +13,8 @@ function OnGameEvent_teamplay_round_start(params) {
 
     // Timer logic replacement
     EntityOutputs.RemoveOutput(PLR_TIMER, "OnSetupFinished", PLR_TIMER_NAME, "Disable", "");
-    EntityOutputs.AddOutput(PLR_TIMER, "OnSetupFinished", "!self", "SetTime", GetRoundTimeString(), 0, -1);
-    EntityOutputs.AddOutput(PLR_TIMER, "OnFinished", "!self", "RunScriptCode", "StartOvertime()", 0, -1);
+    EntityOutputs.AddOutput(PLR_TIMER, "OnSetupFinished", "!self", "SetTime", PLR_GetRoundTimeString(), 0, -1);
+    EntityOutputs.AddOutput(PLR_TIMER, "OnFinished", "!self", "RunScriptCode", "PLR_StartOvertime()", 0, -1);
 
     EntityOutputs.AddOutput(MM_GetEntByName("plr_blu_pathC_start3"), "OnPass", "!self", "RunScriptCode", "MM_HighTowerEvent_DelayedStart()", 0, -1);
 }
@@ -61,7 +61,7 @@ function MM_HighTowerEvent_DelayedStart() {
     MM_GetEntByName("plr_blu_crossover1_branch").Kill();
     MM_GetEntByName("plr_blu_crossover1_relay").Kill();
 
-    AddCrossing([
+    PLR_AddCrossing([
         ["plr_red_crossover1_start", "plr_red_crossover1_end", 2],
         ["plr_blu_crossover1_start", "plr_blu_crossover1_end", 3]
     ]);
@@ -75,17 +75,17 @@ function MM_HighTowerEvent_DelayedStart() {
     EntityOutputs.AddOutput(MM_GetEntByName("clamp_red_positioncart_relay_end"), "OnTrigger", "!self", "RunScriptCode", "SwitchToElevator(2)", 0.95, -1);
     EntityOutputs.AddOutput(MM_GetEntByName("clamp_blu_positioncart_relay_end"), "OnTrigger", "!self", "RunScriptCode", "SwitchToElevator(3)", 0.95, -1);
 
-    EntityOutputs.AddOutput(MM_GetEntByName("relay_red_capture_cart"), "OnTrigger", "!self", "RunScriptCode", "ForceStopCarts()", 0, -1);
-    EntityOutputs.AddOutput(MM_GetEntByName("relay_blu_capture_cart"), "OnTrigger", "!self", "RunScriptCode", "ForceStopCarts()", 0, -1);
+    EntityOutputs.AddOutput(MM_GetEntByName("relay_red_capture_cart"), "OnTrigger", "!self", "RunScriptCode", "PLR_ForceStopCarts()", 0, -1);
+    EntityOutputs.AddOutput(MM_GetEntByName("relay_blu_capture_cart"), "OnTrigger", "!self", "RunScriptCode", "PLR_ForceStopCarts()", 0, -1);
 
     // Add thinks to carts
     PLR_CreateCartAutoUpdater(2, PLR_TEAMS[2].train);
     PLR_CreateCartAutoUpdater(3, PLR_TEAMS[3].train);
 }
 
-::StartOvertimeBase <- StartOvertime;
+::PLR_StartOvertimeBase <- PLR_StartOvertime;
 
-function StartOvertime() {
+function PLR_StartOvertime() {
     local redRollbackRelay = MM_GetEntByName("plr_red_rollback_relay");
     local bluRollbackRelay = MM_GetEntByName("plr_blu_rollback_relay");
 
@@ -95,9 +95,9 @@ function StartOvertime() {
 
     // The only rollback zones are on the elevator, which force disable rollback anyway.
     // Might as well disable rollback right now.
-    DisableOvertimeRollback();
+    PLR_DisableOvertimeRollback();
 
-    StartOvertimeBase();
+    PLR_StartOvertimeBase();
 }
 
 // Override PLR_Advance/PLR_Stop/PLR_TriggerRollback to also control elevator
@@ -156,7 +156,7 @@ function SwitchToElevator(team) {
         EntityOutputs.AddOutput(t.pushzone, "OnNumCappersChanged2", "mm_plr_logiccase_blu", "InValue", "", 0, -1);
     }
 
-    DisableOvertimeRollback();
+    PLR_DisableOvertimeRollback();
 
     EntFireByHandle(t.custom.elv, "SetSpeedForwardModifier", "0.25", 0, null, null);
 

--- a/mega_mod/mapmods/plr_hightower_event.nut
+++ b/mega_mod/mapmods/plr_hightower_event.nut
@@ -33,8 +33,8 @@ function MM_HighTowerEvent_DelayedStart() {
     PLR_TEAMS[2].watcher = MM_GetEntByName("plr_red_watcherC");
     PLR_TEAMS[3].watcher = MM_GetEntByName("plr_blu_watcherC");
 
-    PLR_TEAMS[2].custom.elv = null;
-    PLR_TEAMS[3].custom.elv = null;
+    PLR_TEAMS[2].custom.elv <- null;
+    PLR_TEAMS[3].custom.elv <- null;
 
     PLR_TEAMS[2].blocked = false;
     PLR_TEAMS[3].blocked = false;

--- a/mega_mod/mapmods/plr_matterhorn.nut
+++ b/mega_mod/mapmods/plr_matterhorn.nut
@@ -59,15 +59,15 @@ function OnGameEvent_teamplay_round_start(params) {
         MM_GetEntByName(entName).Kill();
     }
 
-    AddCrossing([
+    PLR_AddCrossing([
         ["ssplr_red_pathA_12", "ssplr_red_pathA_17", 2],
         ["ssplr_blu_pathA_12", "ssplr_blu_pathA_17", 3]
     ]);
 
     // Timer logic replacement
     EntityOutputs.RemoveOutput(PLR_TIMER, "OnSetupFinished", PLR_TIMER_NAME, "Disable", "");
-    EntityOutputs.AddOutput(PLR_TIMER, "OnSetupFinished", "!self", "SetTime", GetRoundTimeString(), 0, -1);
-    EntityOutputs.AddOutput(PLR_TIMER, "OnFinished", "!self", "RunScriptCode", "StartOvertime()", 0, -1);
+    EntityOutputs.AddOutput(PLR_TIMER, "OnSetupFinished", "!self", "SetTime", PLR_GetRoundTimeString(), 0, -1);
+    EntityOutputs.AddOutput(PLR_TIMER, "OnFinished", "!self", "RunScriptCode", "PLR_StartOvertime()", 0, -1);
 
     // team_train_watcher is no longer in charge.
     NetProps.SetPropBool(PLR_TEAMS[2].watcher, "m_bHandleTrainMovement", false);

--- a/mega_mod/mapmods/plr_matterhorn.nut
+++ b/mega_mod/mapmods/plr_matterhorn.nut
@@ -24,10 +24,10 @@ function OnGameEvent_teamplay_round_start(params) {
     PLR_TEAMS[2].train = MM_GetEntByName("ssplr_red_train");
     PLR_TEAMS[3].train = MM_GetEntByName("ssplr_blu_train");
 
-    PLR_TEAMS[2].custom.elv = null;
-    PLR_TEAMS[3].custom.elv = null;
-    PLR_TEAMS[2].custom.atBottom = false;
-    PLR_TEAMS[3].custom.atBottom = false;
+    PLR_TEAMS[2].custom.elv <- null;
+    PLR_TEAMS[3].custom.elv <- null;
+    PLR_TEAMS[2].custom.atBottom <- false;
+    PLR_TEAMS[3].custom.atBottom <- false;
 
     PLR_TEAMS[2].watcher = MM_GetEntByName("ssplr_red_watcherA");
     PLR_TEAMS[3].watcher = MM_GetEntByName("ssplr_blu_watcherA");
@@ -35,15 +35,15 @@ function OnGameEvent_teamplay_round_start(params) {
     PLR_TEAMS[2].logiccase = PLR_CreateLogicCase(2, "mm_plr_logiccase_red");
     PLR_TEAMS[3].logiccase = PLR_CreateLogicCase(3, "mm_plr_logiccase_blu");
 
-    PLR_TEAMS[2].custom.liftLights = MM_GetEntArrayByName("ssplr_red_lift_finale1_lights");
-    PLR_TEAMS[3].custom.liftLights = MM_GetEntArrayByName("ssplr_blu_lift_finale1_lights");
+    PLR_TEAMS[2].custom.liftLights <- MM_GetEntArrayByName("ssplr_red_lift_finale1_lights");
+    PLR_TEAMS[3].custom.liftLights <- MM_GetEntArrayByName("ssplr_blu_lift_finale1_lights");
 
-    PLR_TEAMS[2].custom.wheel = MM_GetEntByName("wheel_red");
-    PLR_TEAMS[3].custom.wheel = MM_GetEntByName("wheel_blu");
+    PLR_TEAMS[2].custom.wheel <- MM_GetEntByName("wheel_red");
+    PLR_TEAMS[3].custom.wheel <- MM_GetEntByName("wheel_blu");
 
     // Elevator speed configs (used when on lift)
-    PLR_TEAMS[2].custom.liftSpeeds = {"s1" : 0.33, "s2" : 0.5, "s3" : 0.66, "ot" : 0.05, "rb" : -0.5};
-    PLR_TEAMS[3].custom.liftSpeeds = {"s1" : 0.33, "s2" : 0.5, "s3" : 0.66, "ot" : 0.05, "rb" : -0.5};
+    PLR_TEAMS[2].custom.liftSpeeds <- {"s1" : 0.33, "s2" : 0.5, "s3" : 0.66, "ot" : 0.05, "rb" : -0.5};
+    PLR_TEAMS[3].custom.liftSpeeds <- {"s1" : 0.33, "s2" : 0.5, "s3" : 0.66, "ot" : 0.05, "rb" : -0.5};
 
     // Rollback zones
     PLR_AddRollbackZone(2, "ssplr_red_path_lift_finale1_4", null, "ssplr_red_path_lift_finale1_1");

--- a/mega_mod/mapmods/plr_matterhorn.nut
+++ b/mega_mod/mapmods/plr_matterhorn.nut
@@ -1,54 +1,56 @@
 ClearGameEventCallbacks();
 IncludeScript("mega_mod/common/plr_overtime.nut");
 
+::ELEVATOR_OVERTIME_SPEED <- 0.1;
+::LIFT_BOTTOM_THRESHOLD <- 0.676;
+::LIFT_BOTTOM_HYSTERESIS <- 0.001;
+
 function OnGameEvent_teamplay_round_start(params) {
 
     InitGlobalVars();
 
-	::PLR_TIMER_NAME <- "ssplr_timer";
+    ::PLR_TIMER_NAME <- "ssplr_timer";
     ::PLR_TIMER = MM_GetEntByName(PLR_TIMER_NAME);
 
-    ::RED_CARTSPARKS_ARRAY <- MM_GetEntArrayByName("ssplr_red_cartsparks");
-    ::BLU_CARTSPARKS_ARRAY <- MM_GetEntArrayByName("ssplr_blu_cartsparks");
+    PLR_TEAMS[2].cartsparks = MM_GetEntArrayByName("ssplr_red_cartsparks");
+    PLR_TEAMS[3].cartsparks = MM_GetEntArrayByName("ssplr_blu_cartsparks");
 
-    ::RED_FLASHINGLIGHT <- MM_GetEntByName("ssplr_red_flashinglight");
-    ::BLU_FLASHINGLIGHT <- MM_GetEntByName("ssplr_blu_flashinglight");
+    PLR_TEAMS[2].flashinglight = MM_GetEntByName("ssplr_red_flashinglight");
+    PLR_TEAMS[3].flashinglight = MM_GetEntByName("ssplr_blu_flashinglight");
 
-    ::RED_PUSHZONE <- MM_GetEntByName("ssplr_red_pushzone");
-    ::BLU_PUSHZONE <- MM_GetEntByName("ssplr_blu_pushzone");
+    PLR_TEAMS[2].pushzone = MM_GetEntByName("ssplr_red_pushzone");
+    PLR_TEAMS[3].pushzone = MM_GetEntByName("ssplr_blu_pushzone");
 
-    ::RED_TRAIN <- MM_GetEntByName("ssplr_red_train");
-    ::BLU_TRAIN <- MM_GetEntByName("ssplr_blu_train");
+    PLR_TEAMS[2].train = MM_GetEntByName("ssplr_red_train");
+    PLR_TEAMS[3].train = MM_GetEntByName("ssplr_blu_train");
 
-    ::RED_ELV <- null;
-    ::BLU_ELV <- null;
+    PLR_TEAMS[2].custom.elv = null;
+    PLR_TEAMS[3].custom.elv = null;
+    PLR_TEAMS[2].custom.atBottom = false;
+    PLR_TEAMS[3].custom.atBottom = false;
 
-    ::RED_AT_BOTTOM <- false;
-    ::BLU_AT_BOTTOM <- false;
+    PLR_TEAMS[2].watcher = MM_GetEntByName("ssplr_red_watcherA");
+    PLR_TEAMS[3].watcher = MM_GetEntByName("ssplr_blu_watcherA");
 
-    ::RED_WATCHER <- MM_GetEntByName("ssplr_red_watcherA");
-    ::BLU_WATCHER <- MM_GetEntByName("ssplr_blu_watcherA");
+    PLR_TEAMS[2].logiccase = PLR_CreateLogicCase(2, "mm_plr_logiccase_red");
+    PLR_TEAMS[3].logiccase = PLR_CreateLogicCase(3, "mm_plr_logiccase_blu");
 
-    ::RED_LOGICCASE <- CreateLogicCase("mm_plr_logiccase_red", "Red");
-    ::BLU_LOGICCASE <- CreateLogicCase("mm_plr_logiccase_blu", "Blu");
+    PLR_TEAMS[2].custom.liftLights = MM_GetEntArrayByName("ssplr_red_lift_finale1_lights");
+    PLR_TEAMS[3].custom.liftLights = MM_GetEntArrayByName("ssplr_blu_lift_finale1_lights");
 
-    ::RED_LIFT_FLASHINGLIGHTS <- MM_GetEntArrayByName("ssplr_red_lift_finale1_lights");
-    ::BLU_LIFT_FLASHINGLIGHTS <- MM_GetEntArrayByName("ssplr_blu_lift_finale1_lights");
+    PLR_TEAMS[2].custom.wheel = MM_GetEntByName("wheel_red");
+    PLR_TEAMS[3].custom.wheel = MM_GetEntByName("wheel_blu");
 
-    ::ELEVATOR_OVERTIME_SPEED <- 0.1;
-    ::LIFT_BOTTOM_THRESHOLD <- 0.676;
-    ::LIFT_BOTTOM_HYSTERESIS <- 0.001;
-
-    ::RED_WHEEL <- MM_GetEntByName("wheel_red")
-    ::BLU_WHEEL <- MM_GetEntByName("wheel_blu")
+    // Elevator speed configs (used when on lift)
+    PLR_TEAMS[2].custom.liftSpeeds = {"s1" : 0.33, "s2" : 0.5, "s3" : 0.66, "ot" : 0.05, "rb" : -0.5};
+    PLR_TEAMS[3].custom.liftSpeeds = {"s1" : 0.33, "s2" : 0.5, "s3" : 0.66, "ot" : 0.05, "rb" : -0.5};
 
     // Rollback zones
-    AddRollbackZone("ssplr_red_path_lift_finale1_4", null, "ssplr_red_path_lift_finale1_1", "Red");
-    AddRollbackZone("ssplr_blu_path_lift_finale1_4", null, "ssplr_blu_path_lift_finale1_1", "Blu");
+    PLR_AddRollbackZone(2, "ssplr_red_path_lift_finale1_4", null, "ssplr_red_path_lift_finale1_1");
+    PLR_AddRollbackZone(3, "ssplr_blu_path_lift_finale1_4", null, "ssplr_blu_path_lift_finale1_1");
 
-	// Crossover logic replacement
-
-	foreach(entName in [
+    // Crossover logic replacement
+    foreach(entName in [
         "ssplr_red_crossover1_branch"
         "ssplr_red_crossover1_relay"
         "ssplr_blu_crossover1_branch"
@@ -57,26 +59,28 @@ function OnGameEvent_teamplay_round_start(params) {
         MM_GetEntByName(entName).Kill();
     }
 
-	AddCrossing("ssplr_red_pathA_12", "ssplr_red_pathA_17", "ssplr_blu_pathA_12", "ssplr_blu_pathA_17", 1);
+    AddCrossing([
+        ["ssplr_red_pathA_12", "ssplr_red_pathA_17", 2],
+        ["ssplr_blu_pathA_12", "ssplr_blu_pathA_17", 3]
+    ]);
 
-	// Timer logic replacement
+    // Timer logic replacement
     EntityOutputs.RemoveOutput(PLR_TIMER, "OnSetupFinished", PLR_TIMER_NAME, "Disable", "");
     EntityOutputs.AddOutput(PLR_TIMER, "OnSetupFinished", "!self", "SetTime", GetRoundTimeString(), 0, -1);
     EntityOutputs.AddOutput(PLR_TIMER, "OnFinished", "!self", "RunScriptCode", "StartOvertime()", 0, -1);
 
     // team_train_watcher is no longer in charge.
-    NetProps.SetPropBool(RED_WATCHER, "m_bHandleTrainMovement", false);
-    NetProps.SetPropBool(BLU_WATCHER, "m_bHandleTrainMovement", false);
+    NetProps.SetPropBool(PLR_TEAMS[2].watcher, "m_bHandleTrainMovement", false);
+    NetProps.SetPropBool(PLR_TEAMS[3].watcher, "m_bHandleTrainMovement", false);
 
     // Hook pre-lift pushzones.
-    EntityOutputs.AddOutput(RED_PUSHZONE, "OnNumCappersChanged2", "mm_plr_logiccase_red", "InValue", "", 0, -1);
-    EntityOutputs.AddOutput(BLU_PUSHZONE, "OnNumCappersChanged2", "mm_plr_logiccase_blu", "InValue", "", 0, -1);
+    EntityOutputs.AddOutput(PLR_TEAMS[2].pushzone, "OnNumCappersChanged2", "mm_plr_logiccase_red", "InValue", "", 0, -1);
+    EntityOutputs.AddOutput(PLR_TEAMS[3].pushzone, "OnNumCappersChanged2", "mm_plr_logiccase_blu", "InValue", "", 0, -1);
 
-    EntityOutputs.AddOutput(RED_PUSHZONE, "OnNumCappersChanged2", "ssplr_red_watcherA", "SetNumTrainCappers", "", 0, -1);
-    EntityOutputs.AddOutput(BLU_PUSHZONE, "OnNumCappersChanged2", "ssplr_blu_watcherA", "SetNumTrainCappers", "", 0, -1);
+    EntityOutputs.AddOutput(PLR_TEAMS[2].pushzone, "OnNumCappersChanged2", "ssplr_red_watcherA", "SetNumTrainCappers", "", 0, -1);
+    EntityOutputs.AddOutput(PLR_TEAMS[3].pushzone, "OnNumCappersChanged2", "ssplr_blu_watcherA", "SetNumTrainCappers", "", 0, -1);
 
-    // elevator logic replacement
-
+    // Elevator logic replacement
     foreach (entName in [
         // HUD logic
         // We have to kill these then recreate the status relays as is because we need to enable fast retriggers.
@@ -154,13 +158,13 @@ function OnGameEvent_teamplay_round_start(params) {
         targetname = "ssplr_blu_lift_finale1_relay_embark"
     });
 
-    EntityOutputs.AddOutput(ssplr_red_lift_finale1_relay_embark, "OnTrigger", "ssplr_red_train", "AddOutput", "manualaccelspeed 999", 0.3, -1)
-    EntityOutputs.AddOutput(ssplr_red_lift_finale1_relay_embark, "OnTrigger", "ssplr_red_train", "AddOutput", "manualdecelspeed 999", 0.3, -1)
-    EntityOutputs.AddOutput(ssplr_red_lift_finale1_relay_embark, "OnTrigger", "!self", "RunScriptCode", "SwitchToElevatorRed()", 0, 1)
+    EntityOutputs.AddOutput(ssplr_red_lift_finale1_relay_embark, "OnTrigger", "ssplr_red_train", "AddOutput", "manualaccelspeed 999", 0.3, -1);
+    EntityOutputs.AddOutput(ssplr_red_lift_finale1_relay_embark, "OnTrigger", "ssplr_red_train", "AddOutput", "manualdecelspeed 999", 0.3, -1);
+    EntityOutputs.AddOutput(ssplr_red_lift_finale1_relay_embark, "OnTrigger", "!self", "RunScriptCode", "SwitchToElevator(2)", 0, 1);
 
-    EntityOutputs.AddOutput(ssplr_blu_lift_finale1_relay_embark, "OnTrigger", "ssplr_blu_train", "AddOutput", "manualaccelspeed 999", 0.3, -1)
-    EntityOutputs.AddOutput(ssplr_blu_lift_finale1_relay_embark, "OnTrigger", "ssplr_blu_train", "AddOutput", "manualdecelspeed 999", 0.3, -1)
-    EntityOutputs.AddOutput(ssplr_blu_lift_finale1_relay_embark, "OnTrigger", "!self", "RunScriptCode", "SwitchToElevatorBlu()", 0, 1)
+    EntityOutputs.AddOutput(ssplr_blu_lift_finale1_relay_embark, "OnTrigger", "ssplr_blu_train", "AddOutput", "manualaccelspeed 999", 0.3, -1);
+    EntityOutputs.AddOutput(ssplr_blu_lift_finale1_relay_embark, "OnTrigger", "ssplr_blu_train", "AddOutput", "manualdecelspeed 999", 0.3, -1);
+    EntityOutputs.AddOutput(ssplr_blu_lift_finale1_relay_embark, "OnTrigger", "!self", "RunScriptCode", "SwitchToElevator(3)", 0, 1);
 
     SpawnEntityFromTable("logic_relay", {
         targetname = "status_off"
@@ -173,7 +177,7 @@ function OnGameEvent_teamplay_round_start(params) {
         "OnTrigger#6": "status_sign_red,Skin,2,0,-1"
         "OnTrigger#7": "player,RunScriptCode,self.SetScriptOverlayMaterial(\"hud/plr_gray\")"
     });
- 
+
     SpawnEntityFromTable("logic_relay", {
         targetname = "status_red"
         spawnflags = "2"
@@ -215,323 +219,234 @@ function OnGameEvent_teamplay_round_start(params) {
     });
 
     // track elevator bottom out
-    AddThinkToEnt(RED_WATCHER, "CheckBottomRedThink");
-    AddThinkToEnt(BLU_WATCHER, "CheckBottomBluThink");
+    AddThinkToEnt(PLR_TEAMS[2].watcher, "CheckBottomThink_2");
+    AddThinkToEnt(PLR_TEAMS[3].watcher, "CheckBottomThink_3");
 
     // Add thinks to carts
-    CreateCartAutoUpdater(RED_TRAIN, 2);
-    CreateCartAutoUpdater(BLU_TRAIN, 3);
+    PLR_CreateCartAutoUpdater(2, PLR_TEAMS[2].train);
+    PLR_CreateCartAutoUpdater(3, PLR_TEAMS[3].train);
 }
 
-::CartThinkRedBase <- CartThinkRed;
-::CartThinkBluBase <- CartThinkBlu;
+// Override PLR_Advance/PLR_Stop/PLR_TriggerRollback to also control elevator + wheel
+::PLR_Advance_Base <- PLR_Advance;
+::PLR_Stop_Base <- PLR_Stop;
+::PLR_TriggerRollback_Base <- PLR_TriggerRollback;
 
-function CartThinkRed() {
-    if (::RED_AT_BOTTOM) return 0.5;
-    CartThinkRedBase();
-}
-
-function CartThinkBlu() {
-    if (::BLU_AT_BOTTOM) return 0.5;
-    CartThinkBluBase();
-}
-
-::AdvanceRedBase <- AdvanceRed;
-::StopRedBase <- StopRed;
-::TriggerRollbackRedBase <- TriggerRollbackRed;
-::AdvanceBluBase <- AdvanceBlu;
-::StopBluBase <- StopBlu;
-::TriggerRollbackBluBase <- TriggerRollbackBlu;
-
-// ::UpdateRedCartBase <- UpdateRedCart;
-// ::UpdateBluCartBase <- UpdateBluCart;
-
-function AdvanceRed(speed, dynamic = true) {
-    if (RED_ELV) dynamic = false;
-    AdvanceRedBase(speed, dynamic);
-    if (RED_ELV) {
-        ::RED_AT_BOTTOM = false;
-        EntFireByHandle(RED_ELV, "SetSpeedDirAccel", "" + speed, 0, null, null);
-        EntFireByHandle(RED_WHEEL, "SetSpeed", "" + speed, 0, null, null);
-        foreach(light in RED_LIFT_FLASHINGLIGHTS) {
+function PLR_Advance(team, baseSpeed, dynamic = true) {
+    local t = PLR_TEAMS[team];
+    if (t.custom.elv) {
+        dynamic = false;
+        t.custom.atBottom = false;
+    }
+    PLR_Advance_Base(team, baseSpeed, dynamic);
+    if(t.custom.elv) {
+        EntFireByHandle(t.custom.elv, "SetSpeedDirAccel", "" + baseSpeed, 0, null, null);
+        EntFireByHandle(t.custom.wheel, "SetSpeed", "" + baseSpeed, 0, null, null);
+        foreach(light in t.custom.liftLights) {
             EntFireByHandle(light, "Start", "", 0, null, null);
         }
     }
 }
 
-function StopRed() {
-    StopRedBase();
-    if (RED_ELV) {
-        EntFireByHandle(RED_ELV, "SetSpeedDirAccel", "0.0", 0, null, null);
-        local currentSpeed = NetProps.GetPropFloat(RED_ELV, "m_flSpeed");
-        if (currentSpeed == 0) EntFireByHandle(RED_ELV, "Stop", "", 0, null, null);
-        EntFireByHandle(RED_WHEEL, "Stop", "", 0, null, null);
-        foreach(light in RED_LIFT_FLASHINGLIGHTS) {
+function PLR_Stop(team) {
+    local t = PLR_TEAMS[team];
+    PLR_Stop_Base(team);
+    if(t.custom.elv) {
+        EntFireByHandle(t.custom.elv, "SetSpeedDirAccel", "0.0", 0, null, null);
+        local currentSpeed = NetProps.GetPropFloat(t.custom.elv, "m_flSpeed");
+        if (currentSpeed == 0) EntFireByHandle(t.custom.elv, "Stop", "", 0, null, null);
+        EntFireByHandle(t.custom.wheel, "Stop", "", 0, null, null);
+        foreach(light in t.custom.liftLights) {
             EntFireByHandle(light, "Stop", "", 0, null, null);
         }
     }
 }
 
-function TriggerRollbackRed() {
-    TriggerRollbackRedBase();
-    if(RED_ELV) {
-        EntFireByHandle(RED_ELV, "SetSpeedDirAccel", "" + ROLLBACK_SPEED_RED, 0, null, null);
-        EntFireByHandle(RED_WHEEL, "SetSpeed", "" + ROLLBACK_SPEED_RED, 0, null, null);
-        foreach(light in RED_LIFT_FLASHINGLIGHTS) {
+function PLR_TriggerRollback(team, multiplier = 1.0) {
+    local t = PLR_TEAMS[team];
+    local rbSpeed = t.rollbackSpeed * multiplier;
+    PLR_TriggerRollback_Base(team, multiplier);
+    if(t.custom.elv) {
+        EntFireByHandle(t.custom.elv, "SetSpeedDirAccel", "" + rbSpeed, 0, null, null);
+        EntFireByHandle(t.custom.wheel, "SetSpeed", "" + rbSpeed, 0, null, null);
+        foreach(light in t.custom.liftLights) {
             EntFireByHandle(light, "Stop", "", 0, null, null);
         }
     }
 }
 
-function AdvanceBlu(speed, dynamic = true) {
-    if (BLU_ELV) dynamic = false;
-    AdvanceBluBase(speed, dynamic);
-    if (BLU_ELV) {
-        ::BLU_AT_BOTTOM = false;
-        EntFireByHandle(BLU_ELV, "SetSpeedDirAccel", "" + speed, 0, null, null);
-        EntFireByHandle(BLU_WHEEL, "SetSpeed", "" + speed, 0, null, null);
-        foreach(light in BLU_LIFT_FLASHINGLIGHTS) {
-            EntFireByHandle(light, "Start", "", 0, null, null);
-        }
-    }
-}
+// Override PLR_UpdateCart for counter-boost logic
+::PLR_UpdateCart_Base <- PLR_UpdateCart;
 
-function StopBlu() {
-    StopBluBase();
-    if (BLU_ELV) {
-        EntFireByHandle(BLU_ELV, "SetSpeedDirAccel", "0.0", 0, null, null);
-        local currentSpeed = NetProps.GetPropFloat(BLU_ELV, "m_flSpeed");
-        if (currentSpeed == 0) EntFireByHandle(BLU_ELV, "Stop", "", 0, null, null);
-        EntFireByHandle(BLU_WHEEL, "Stop", "", 0, null, null);
-        foreach(light in BLU_LIFT_FLASHINGLIGHTS) {
-            EntFireByHandle(light, "Stop", "", 0, null, null);
-        }
-    }
-}
+function PLR_UpdateCart(team, pushstate) {
+    local t = PLR_TEAMS[team];
+    local other = team == 2 ? 3 : 2;
+    local otherT = PLR_TEAMS[other];
 
-function TriggerRollbackBlu() {
-    TriggerRollbackBluBase();
-    if(BLU_ELV) {
-        EntFireByHandle(BLU_ELV, "SetSpeedDirAccel", "" + ROLLBACK_SPEED_BLU, 0, null, null);
-        EntFireByHandle(BLU_WHEEL, "SetSpeed", "" + ROLLBACK_SPEED_BLU, 0, null, null);
-        foreach(light in BLU_LIFT_FLASHINGLIGHTS) {
-            EntFireByHandle(light, "Stop", "", 0, null, null);
-        }
-    }
-}
-
-// The RED/BLU specific hud only appears when the respective counter-boost is active.
-function UpdateHUD() {
-    local toTrigger = null;
-    if (!RED_ELV || !BLU_ELV) {
+    if (++PLR_UPDATE_DEPTH > PLR_MAX_UPDATE_DEPTH) {
+        --PLR_UPDATE_DEPTH;
         return;
-    } else if (CASE_RED > 0 && CASE_BLU > 0) { // Both carts being pushed
-        toTrigger = "status_off"
-    } else if (CASE_RED > 0 && CASE_BLU == 0 && !BLU_AT_BOTTOM) { // RED counter-boost
-        toTrigger = "status_red"
-    } else if (CASE_RED == 0 && !RED_AT_BOTTOM && CASE_BLU > 0) { // BLU counter-boost
-        toTrigger = "status_blu"
-    } else if (!OVERTIME_ACTIVE && CASE_RED == 0 && CASE_BLU == 0) { // Hold
-        toTrigger = "status_yellow"
+    }
+
+    t.pushstate = pushstate;
+
+    if(t.blocked) {
+        --PLR_UPDATE_DEPTH;
+        return;
+    }
+
+    local liftsBothOn = t.custom.elv && otherT.custom.elv;
+
+    // Counter-boost: if opponent is NOT pushing and NOT at bottom, speed is halved
+    local isCounterBoost = !t.custom.elv || (!otherT.custom.atBottom && otherT.pushstate == 0);
+    local speedFactor = isCounterBoost ? 1.0 : 0.5;
+
+    if(pushstate == -1) {
+        PLR_Stop(team);
+        --PLR_UPDATE_DEPTH;
+        return;
+    }
+
+    if(pushstate == 1) {
+        PLR_Advance(team, t.speed1 * speedFactor);
+    } else if(pushstate == 2) {
+        PLR_Advance(team, t.speed2 * speedFactor);
+    } else if(pushstate >= 3) {
+        PLR_Advance(team, t.speed3 * speedFactor);
+    }
+
+    if(pushstate == 0) {
+        if(otherT.pushstate == 0 && OVERTIME_ACTIVE) {
+            PLR_Advance(team, t.overtimeSpeed);
+            if(!otherT.blocked) PLR_Advance(other, otherT.overtimeSpeed);
+        } else if(!(OVERTIME_ACTIVE && ROLLBACK_DISABLED) && t.rollstate == -1
+            && !t.custom.atBottom
+            && !(t.custom.elv && otherT.custom.elv && otherT.pushstate == 0)) {
+            PLR_TriggerRollback(team);
+        } else {
+            PLR_Stop(team);
+        }
+    } else if((otherT.custom.elv || OVERTIME_ACTIVE) && otherT.pushstate == 0) {
+        PLR_UpdateCart(other, 0);
+    }
+
+    // Force update other cart for elevator coordination
+    if(liftsBothOn && !OVERTIME_ACTIVE) {
+        if(pushstate == 0 && otherT.pushstate == 0) {
+            PLR_Stop(other);
+        } else if(pushstate != 0 && otherT.pushstate == 0) {
+            PLR_TriggerRollback(other);
+        }
+    }
+
+    UpdateHUD();
+    --PLR_UPDATE_DEPTH;
+}
+
+function UpdateHUD() {
+    local t2 = PLR_TEAMS[2];
+    local t3 = PLR_TEAMS[3];
+
+    local toTrigger = null;
+    if(!t2.custom.elv || !t3.custom.elv) {
+        return;
+    } else if(t2.pushstate > 0 && t3.pushstate > 0) {
+        toTrigger = "status_off";
+    } else if(t2.pushstate > 0 && t3.pushstate == 0 && !t3.custom.atBottom) {
+        toTrigger = "status_red";
+    } else if(t2.pushstate == 0 && !t2.custom.atBottom && t3.pushstate > 0) {
+        toTrigger = "status_blu";
+    } else if(!OVERTIME_ACTIVE && t2.pushstate == 0 && t3.pushstate == 0) {
+        toTrigger = "status_yellow";
     } else {
-        toTrigger = "status_off"
+        toTrigger = "status_off";
     }
 
     MM_GetEntByName(toTrigger).AcceptInput("Trigger", "", null, null);
 }
 
-function UpdateRedCart(caseNumber, nestedCall = false) {
-    ::CASE_RED = caseNumber;
+function SwitchToElevator(team) {
+    local t = PLR_TEAMS[team];
+    local lifts = t.custom.liftSpeeds;
 
-    if(BLOCK_RED) return;
+    t.blocked = true;
+    t.custom.atBottom = true;
+    PLR_Advance(team, 1.0);
 
-    local isCounterBoost = !RED_ELV || (BLU_ELV && !BLU_AT_BOTTOM && CASE_BLU) == 0;
-    local speedFactor = isCounterBoost ? 1.0 : 0.5;
+    if(t.flashinglight) t.flashinglight.AcceptInput("Stop", "", null, null);
+    foreach(spark in t.cartsparks) spark.AcceptInput("Stop", "", null, null);
 
-    if(CASE_RED == 1) {
-        AdvanceRed(TIMES_1_SPEED_RED * speedFactor);
-    } else if(CASE_RED == 2) {
-        AdvanceRed(TIMES_2_SPEED_RED * speedFactor);
-    } else if(CASE_RED >= 3) {
-        AdvanceRed(TIMES_3_SPEED_RED * speedFactor);
-    } else if (CASE_RED == -1) {
-        StopRed();
+    if(team == 2) {
+        t.custom.elv = MM_GetEntByName("ssplr_red_lift_finale1_train");
+        t.pushzone = MM_GetEntByName("ssplr_red_lift_finale1_pushzone");
+        t.cartsparks = MM_GetEntArrayByName("ssplr_red_lift_finale1_sparks");
+        t.flashinglight = null;
+
+        EntityOutputs.AddOutput(MM_GetEntByName("ssplr_red_path_lift_finale1_4"), "OnPass", t.train.GetName(), "Stop", "", 0, 1);
+        EntityOutputs.AddOutput(MM_GetEntByName("ssplr_red_path_lift_finale1_4"), "OnPass", t.custom.elv.GetName(), "Stop", "", 0, 1);
+        EntityOutputs.AddOutput(MM_GetEntByName("ssplr_red_path_lift_finale1_4"), "OnPass", "!self",
+            "RunScriptCode", "PLR_UpdateCart(2, PLR_TEAMS[2].pushstate)", 0.05, 1);
+
+        EntFireByHandle(MM_GetEntByName("ssplr_red_flashinglight"), "Stop", "", 1.0, null, null);
+        foreach(spark in MM_GetEntArrayByName("ssplr_red_cartsparks")) EntFireByHandle(spark, "Stop", "", 0.1, null, null);
+    } else {
+        t.custom.elv = MM_GetEntByName("ssplr_blu_lift_finale1_train");
+        t.pushzone = MM_GetEntByName("ssplr_blu_lift_finale1_pushzone");
+        t.cartsparks = MM_GetEntArrayByName("ssplr_blu_lift_finale1_sparks");
+        t.flashinglight = null;
+
+        EntityOutputs.AddOutput(MM_GetEntByName("ssplr_blu_path_lift_finale1_4"), "OnPass", t.train.GetName(), "Stop", "", 0, 1);
+        EntityOutputs.AddOutput(MM_GetEntByName("ssplr_blu_path_lift_finale1_4"), "OnPass", t.custom.elv.GetName(), "Stop", "", 0, 1);
+        EntityOutputs.AddOutput(MM_GetEntByName("ssplr_blu_path_lift_finale1_4"), "OnPass", "!self",
+            "RunScriptCode", "PLR_UpdateCart(3, PLR_TEAMS[3].pushstate)", 0.05, 1);
+
+        EntFireByHandle(MM_GetEntByName("ssplr_blu_flashinglight"), "Stop", "", 1.0, null, null);
+        foreach(spark in MM_GetEntArrayByName("ssplr_blu_cartsparks")) EntFireByHandle(spark, "Stop", "", 0.1, null, null);
     }
 
-    if (nestedCall) return;
+    EntityOutputs.AddOutput(t.pushzone, "OnNumCappersChanged2",
+        team == 2 ? "mm_plr_logiccase_red" : "mm_plr_logiccase_blu", "InValue", "", 0, -1);
 
-    if(CASE_RED == 0) {
-        if(CASE_BLU == 0 && OVERTIME_ACTIVE) {
-            AdvanceRed(OVERTIME_SPEED_RED);
-            if(!BLOCK_BLU) AdvanceBlu(OVERTIME_SPEED_BLU);
-        } else if (!(OVERTIME_ACTIVE && ROLLBACK_DISABLED) && RED_ROLLSTATE == -1 && !RED_AT_BOTTOM
-            && !(RED_ELV && BLU_ELV && CASE_BLU == 0)) { // If BLU cart is on the lift and not being pushed, activate HOLD state.
-            TriggerRollbackRed();
-        } else {
-            StopRed();
-        }
-    } else if ((BLU_ELV || OVERTIME_ACTIVE) && CASE_BLU == 0) {
-        UpdateBluCart(0);
-    }
+    // Update speed configs for elevator mode
+    t.rollbackSpeed = lifts.rb;
+    t.overtimeSpeed = lifts.ot;
+    t.speed1 = lifts.s1;
+    t.speed2 = lifts.s2;
+    t.speed3 = lifts.s3;
 
-    // need to force update other cart to account for various elevator states
-    if (RED_ELV && BLU_ELV && !OVERTIME_ACTIVE) {
-        if (CASE_RED == 0 && CASE_BLU == 0) { // HOLD
-            StopBlu();
-        } else if (CASE_RED != 0 && CASE_BLU == 0) { // Rollback other cart
-            TriggerRollbackBlu();
-        } else { // Counterboost/stop counterboosting other cart
-            UpdateBluCart(CASE_BLU, true);
-        }
-    }
+    EntFireByHandle(Gamerules(), "RunScriptCode", "PLR_Stop(" + team + "); PLR_TEAMS[" + team + "].blocked = false", 1.0, null, null);
+    EntFireByHandle(Gamerules(), "RunScriptCode", "PLR_UpdateCart(" + team + ", PLR_TEAMS[" + team + "].pushstate)", 1.05, null, null);
 
     UpdateHUD();
 }
 
-function UpdateBluCart(caseNumber, nestedCall = false) {
-    ::CASE_BLU = caseNumber;
-
-    if(BLOCK_BLU) return;
-
-    local isCounterBoost = !BLU_ELV || (RED_ELV && !RED_AT_BOTTOM && CASE_RED) == 0;
-    local speedFactor = isCounterBoost ? 1.0 : 0.5;
-
-    if(CASE_BLU == 1) {
-        AdvanceBlu(TIMES_1_SPEED_BLU * speedFactor);
-    } else if(CASE_BLU == 2) {
-        AdvanceBlu(TIMES_2_SPEED_BLU * speedFactor);
-    } else if(CASE_BLU >= 3) {
-        AdvanceBlu(TIMES_3_SPEED_BLU * speedFactor);
-    } else if (CASE_BLU == -1) {
-        StopBlu();
-    }
-
-    if (nestedCall) return;
-
-    if(CASE_BLU == 0) {
-        if(CASE_RED == 0 && OVERTIME_ACTIVE) {
-            AdvanceBlu(OVERTIME_SPEED_BLU);
-            if(!BLOCK_RED) AdvanceRed(OVERTIME_SPEED_RED);
-        } else if (!(OVERTIME_ACTIVE && ROLLBACK_DISABLED) && BLU_ROLLSTATE == -1 && !BLU_AT_BOTTOM
-            && !(BLU_ELV && RED_ELV && CASE_RED == 0)) { // If both carts are on the lift and not being pushed, activate HOLD state.
-            TriggerRollbackBlu();
-        } else {
-            StopBlu();
-        }
-    } else if ((RED_ELV || OVERTIME_ACTIVE) && CASE_RED == 0) {
-        UpdateRedCart(0);
-    }
-
-    // need to force update other cart to account for various elevator states
-    if (RED_ELV && BLU_ELV && !OVERTIME_ACTIVE) {
-        if (CASE_BLU == 0 && CASE_RED == 0) { // HOLD
-            StopRed();
-        } else if (CASE_BLU != 0 && CASE_RED == 0) { // Rollback other cart
-            TriggerRollbackRed();
-        } else { // Counterboost/stop counterboosting other cart
-            UpdateRedCart(CASE_RED, true);
-        }
-    }
-
-    UpdateHUD();
-}
-
-// New speeds assume counter-boost is in effect (if not, use 50% of given value)
-function SwitchToElevatorRed() {
-    ::BLOCK_RED <- true;
-    ::RED_AT_BOTTOM <- true;
-    AdvanceRed(1.0);
-
-    RED_FLASHINGLIGHT.AcceptInput("Stop", "", null, null);
-    foreach (spark in RED_CARTSPARKS_ARRAY) spark.AcceptInput("Stop", "", null, null);
-
-    ::RED_ELV <- MM_GetEntByName("ssplr_red_lift_finale1_train");
-    ::RED_PUSHZONE <- MM_GetEntByName("ssplr_red_lift_finale1_pushzone");
-    ::RED_CARTSPARKS_ARRAY <- MM_GetEntArrayByName("ssplr_red_lift_finale1_sparks")
-    ::RED_FLASHINGLIGHT <- null;
-
-    EntityOutputs.AddOutput(RED_PUSHZONE, "OnNumCappersChanged2", "mm_plr_logiccase_red", "InValue", "", 0, -1);
-    ROLLBACK_SPEED_RED = -0.5;
-    OVERTIME_SPEED_RED = 0.05;
-    TIMES_1_SPEED_RED = 0.33;
-    TIMES_2_SPEED_RED = 0.5;
-    TIMES_3_SPEED_RED = 0.66;
-
-    EntityOutputs.AddOutput(MM_GetEntByName("ssplr_red_path_lift_finale1_4"), "OnPass", RED_TRAIN.GetName(), "Stop", "", 0, 1);
-    EntityOutputs.AddOutput(MM_GetEntByName("ssplr_red_path_lift_finale1_4"), "OnPass", RED_ELV.GetName(), "Stop", "", 0, 1);
-    EntityOutputs.AddOutput(MM_GetEntByName("ssplr_red_path_lift_finale1_4"), "OnPass", "!self", "RunScriptCode", "UpdateRedCart(CASE_RED)", 0.05, 1);
-
-    EntFireByHandle(MM_GetEntByName("ssplr_red_flashinglight"), "Stop", "", 1.0, null, null);
-    foreach (spark in MM_GetEntArrayByName("ssplr_red_cartsparks")) EntFireByHandle(spark, "Stop", "", 0.1, null, null);
-
-    EntFireByHandle(Gamerules(), "RunScriptCode", "StopRed(); ::BLOCK_RED <- false", 1.0, null, null);
-    EntFireByHandle(Gamerules(), "RunScriptCode", "UpdateRedCart(CASE_RED)", 1.05, null, null);
-
-    UpdateHUD();
-}
-
-function SwitchToElevatorBlu() {
-    ::BLOCK_BLU <- true;
-    ::BLU_AT_BOTTOM <- true;
-    AdvanceBlu(1.0);
-
-    ::BLU_ELV <- MM_GetEntByName("ssplr_blu_lift_finale1_train");
-    ::BLU_PUSHZONE <- MM_GetEntByName("ssplr_blu_lift_finale1_pushzone");
-    ::BLU_CARTSPARKS_ARRAY <- MM_GetEntArrayByName("ssplr_blu_lift_finale1_sparks")
-    ::BLU_FLASHINGLIGHT <- null;
-
-    EntityOutputs.AddOutput(BLU_PUSHZONE, "OnNumCappersChanged2", "mm_plr_logiccase_blu", "InValue", "", 0, -1);
-    ROLLBACK_SPEED_BLU = -0.5;
-    OVERTIME_SPEED_BLU = 0.05;
-    TIMES_1_SPEED_BLU = 0.33;
-    TIMES_2_SPEED_BLU = 0.5;
-    TIMES_3_SPEED_BLU = 0.66;
-
-    EntityOutputs.AddOutput(MM_GetEntByName("ssplr_blu_path_lift_finale1_4"), "OnPass", BLU_TRAIN.GetName(), "Stop", "", 0, 1)
-    EntityOutputs.AddOutput(MM_GetEntByName("ssplr_blu_path_lift_finale1_4"), "OnPass", BLU_ELV.GetName(), "Stop", "", 0, 1)
-    EntityOutputs.AddOutput(MM_GetEntByName("ssplr_blu_path_lift_finale1_4"), "OnPass", "!self", "RunScriptCode", "UpdateBluCart(CASE_BLU)", 0.05, 1);
-
-    EntFireByHandle(MM_GetEntByName("ssplr_blu_flashinglight"), "Stop", "", 1.0, null, null);
-    foreach (spark in MM_GetEntArrayByName("ssplr_blu_cartsparks")) EntFireByHandle(spark, "Stop", "", 0.1, null, null);
-
-    EntFireByHandle(Gamerules(), "RunScriptCode", "StopBlu(); ::BLOCK_BLU <- false", 1.0, null, null);
-    EntFireByHandle(Gamerules(), "RunScriptCode", "UpdateBluCart(CASE_BLU)", 1.05, null, null);
-
-    UpdateHUD();
-}
-
-function CheckBottomRedThink() {
-    local oldValue = RED_AT_BOTTOM;
-    local position = NetProps.GetPropFloat(RED_WATCHER, "m_flTotalProgress");
+function CheckBottomThink(team) {
+    local t = PLR_TEAMS[team];
+    local other = team == 2 ? 3 : 2;
+    local oldValue = t.custom.atBottom;
+    local position = NetProps.GetPropFloat(t.watcher, "m_flTotalProgress");
 
     local newValue = null;
-    if (RED_ELV && position > LIFT_BOTTOM_THRESHOLD + LIFT_BOTTOM_HYSTERESIS) newValue = false;
-    else if (RED_ELV && position < LIFT_BOTTOM_THRESHOLD) newValue = true;
+    if(t.custom.elv && position > LIFT_BOTTOM_THRESHOLD + LIFT_BOTTOM_HYSTERESIS) newValue = false;
+    else if(t.custom.elv && position < LIFT_BOTTOM_THRESHOLD) newValue = true;
 
-    if (newValue != null && oldValue != newValue) {
-        ::RED_AT_BOTTOM <- newValue;
-        //printl("RED_AT_BOTTOM: " + newValue);
-        EntFireByHandle(Gamerules(), "RunScriptCode", "::UpdateRedCart(CASE_RED)", 0.1, null, null);
-        EntFireByHandle(Gamerules(), "RunScriptCode", "::UpdateBluCart(CASE_BLU)", 0.1, null, null);
+    if(newValue != null && oldValue != newValue) {
+        t.custom.atBottom = newValue;
+        EntFireByHandle(Gamerules(), "RunScriptCode", "PLR_UpdateCart(" + team + ", PLR_TEAMS[" + team + "].pushstate)", 0.1, null, null);
+        EntFireByHandle(Gamerules(), "RunScriptCode", "PLR_UpdateCart(" + other + ", PLR_TEAMS[" + other + "].pushstate)", 0.1, null, null);
     }
     return -1;
 }
 
-function CheckBottomBluThink() {
-    local oldValue = BLU_AT_BOTTOM;
-    local position = NetProps.GetPropFloat(BLU_WATCHER, "m_flTotalProgress");
-
-    local newValue = null;
-    if (BLU_ELV && position > LIFT_BOTTOM_THRESHOLD + LIFT_BOTTOM_HYSTERESIS) newValue = false;
-    else if (BLU_ELV && position < LIFT_BOTTOM_THRESHOLD) newValue = true;
-
-    if (newValue != null && oldValue != newValue) {
-        ::BLU_AT_BOTTOM <- newValue;
-        //printl("BLU_AT_BOTTOM: " + newValue);
-        EntFireByHandle(Gamerules(), "RunScriptCode", "::UpdateBluCart(CASE_BLU)", 0.1, null, null);
-        EntFireByHandle(Gamerules(), "RunScriptCode", "::UpdateRedCart(CASE_RED)", 0.1, null, null);
+// Create captured-think functions for each team
+(function() {
+    local root = getroottable();
+    local teams = [2, 3];
+    foreach(team in teams) {
+        local thinkName = "CheckBottomThink_" + team;
+        local capturedTeam = team;
+        root[thinkName] <- function() { return CheckBottomThink(capturedTeam); };
     }
-    return -1;
-}
+})();
 
 __CollectGameEventCallbacks(this);

--- a/mega_mod/mapmods/plr_nightfall_final.nut
+++ b/mega_mod/mapmods/plr_nightfall_final.nut
@@ -70,15 +70,15 @@ function OnGameEvent_teamplay_round_start(params) {
         MM_GetEntByName(entName).Kill();
     }
 
-    AddCrossing([
+    PLR_AddCrossing([
         ["plr_red_pathA15", "plr_red_pathA16", 2],
         ["plr_blu_pathA15", "plr_blu_pathA16", 3]
     ]);
-    AddCrossing([
+    PLR_AddCrossing([
         ["plr_red_pathB_crossover2_start", "plr_red_pathB_crossover2_end", 2],
         ["plr_blu_pathB_crossover2_start", "plr_blu_pathB_crossover2_end", 3]
     ]);
-    AddCrossing([
+    PLR_AddCrossing([
         ["plr_red_crossover3_start", "plr_red_pathC_29", 2],
         ["plr_blu_crossover3_start", "plr_blu_pathC_29", 3]
     ]);
@@ -115,8 +115,8 @@ function OnGameEvent_teamplay_round_start(params) {
     EntityOutputs.AddOutput(MM_GetEntByName("plr_blu_pathC_slopeA2"), "OnPass", "plr_blu_train", "SetSpeedForwardModifier", "0.5", 0, -1);
 
     // Timer logic
-    EntityOutputs.AddOutput(PLR_TIMER, "OnFinished", "!self", "RunScriptCode", "StartOvertime()", 0, -1);
-    EntityOutputs.AddOutput(PLR_TIMER, "OnSetupFinished", "!self", "SetTime", GetRoundTimeString(45), 0, -1);
+    EntityOutputs.AddOutput(PLR_TIMER, "OnFinished", "!self", "RunScriptCode", "PLR_StartOvertime()", 0, -1);
+    EntityOutputs.AddOutput(PLR_TIMER, "OnSetupFinished", "!self", "SetTime", PLR_GetRoundTimeString(45), 0, -1);
 
     SpawnEntityFromTable("team_round_timer", {
         setup_length = 45,
@@ -125,7 +125,7 @@ function OnGameEvent_teamplay_round_start(params) {
         timer_length = 600,
         StartDisabled = 1,
         show_in_hud = 0,
-        "OnFinished#1" : "!self,RunScriptCode,StartOvertime(),0,1",
+        "OnFinished#1" : "!self,RunScriptCode,PLR_StartOvertime(),0,1",
         "OnSetupFinished#1" : "plr_red_pushzone,Enable,,0,1",
         "OnSetupFinished#2" : "plr_blu_pushzone,Enable,,0,1",
         "OnSetupFinished#3" : "plr_siren,PlaySound,,0,1",
@@ -139,7 +139,7 @@ function OnGameEvent_teamplay_round_start(params) {
         timer_length = 600,
         StartDisabled = 1,
         show_in_hud = 0,
-        "OnFinished#1" : "!self,RunScriptCode,StartOvertime(),0,1"
+        "OnFinished#1" : "!self,RunScriptCode,PLR_StartOvertime(),0,1"
     });
 
     // team_train_watcher is no longer in charge.
@@ -188,7 +188,7 @@ function OnRound2Start() {
     PLR_TEAMS[2].watcher = MM_GetEntByName("plr_red_watcherB");
     PLR_TEAMS[3].watcher = MM_GetEntByName("plr_blu_watcherB");
 
-    EntityOutputs.AddOutput(PLR_TIMER, "OnSetupFinished", "!self", "SetTime", GetRoundTimeString(45), 0, -1);
+    EntityOutputs.AddOutput(PLR_TIMER, "OnSetupFinished", "!self", "SetTime", PLR_GetRoundTimeString(45), 0, -1);
     EntFireByHandle(PLR_TIMER, "ShowInHud", "1", 0, null, null);
     EntFireByHandle(PLR_TIMER, "Enable", "", 0.1, null, null);
 
@@ -201,7 +201,7 @@ function OnRound2Start() {
         PLR_TEAMS[3].train.AcceptInput("TeleportToPathTrack", "plr_blu_pathB_start1", null, null);
     }
 
-    ResetCartStates();
+    PLR_ResetCartStates();
 }
 
 function OnRound3Start() {
@@ -214,27 +214,28 @@ function OnRound3Start() {
     PLR_TEAMS[2].watcher = MM_GetEntByName("plr_red_watcherC");
     PLR_TEAMS[3].watcher = MM_GetEntByName("plr_blu_watcherC");
 
-    EntityOutputs.AddOutput(PLR_TIMER, "OnSetupFinished", "!self", "SetTime", GetRoundTimeString(), 0, -1);
+    EntityOutputs.AddOutput(PLR_TIMER, "OnSetupFinished", "!self", "SetTime", PLR_GetRoundTimeString(), 0, -1);
     EntFireByHandle(PLR_TIMER, "ShowInHud", "1", 0, null, null);
     EntFireByHandle(PLR_TIMER, "Enable", "", 0.1, null, null);
 
     // Handle cart warp
     MM_GetEntByName("plr_stageC_start_case").AcceptInput("InValue", "" + ROUND_WIN_COUNTER, null, null);
 
-    ResetCartStates();
+    PLR_ResetCartStates();
 }
 
-::WinRed_Base <- WinRed;
-::WinBlu_Base <- WinBlu;
+::PLR_TeamWin_Base <- PLR_TeamWin;
 
-function WinRed() {
-    WinRed_Base();
-    ::ROUND_WIN_COUNTER <- ROUND_WIN_COUNTER + 2;
-}
+function PLR_TeamWin(team) {
+    PLR_TeamWin_Base(team);
 
-function WinBlu() {
-    WinBlu_Base();
-    ::ROUND_WIN_COUNTER <- ROUND_WIN_COUNTER + 3;
+    // There is a logic case which handles the advantage the winning team has on later stages.
+    // A round counter increments by 2 when RED wins a stage and 3 when BLU wins a stage.
+    // After stage 1, the count is either 2 or 3, which determines cart starting positions for stage 2.
+    // After stage 2, the count is either 4 (RED+RED), 5 (RED+BLU), or 6 (BLU+BLU), which determines cart starting positions for stage 3.
+    if (team >= 2) {
+        ::ROUND_WIN_COUNTER <- ROUND_WIN_COUNTER + team;
+    }
 }
 
 __CollectGameEventCallbacks(this);

--- a/mega_mod/mapmods/plr_nightfall_final.nut
+++ b/mega_mod/mapmods/plr_nightfall_final.nut
@@ -12,48 +12,45 @@ function OnGameEvent_teamplay_round_start(params) {
     ::PLR_TIMER_NAME <- "plr_timer";
     ::PLR_TIMER = MM_GetEntByName(PLR_TIMER_NAME);
 
-    ::RED_CARTSPARKS_ARRAY <- MM_GetEntArrayByName("plr_red_cartsparks");
-    ::BLU_CARTSPARKS_ARRAY <- MM_GetEntArrayByName("plr_blu_cartsparks");
+    PLR_TEAMS[2].cartsparks = MM_GetEntArrayByName("plr_red_cartsparks");
+    PLR_TEAMS[3].cartsparks = MM_GetEntArrayByName("plr_blu_cartsparks");
 
-    ::RED_FLASHINGLIGHT <- MM_GetEntByName("plr_red_flashinglight");
-    ::BLU_FLASHINGLIGHT <- MM_GetEntByName("plr_blu_flashinglight");
+    PLR_TEAMS[2].flashinglight = MM_GetEntByName("plr_red_flashinglight");
+    PLR_TEAMS[3].flashinglight = MM_GetEntByName("plr_blu_flashinglight");
 
-    ::RED_PUSHZONE <- MM_GetEntByName("plr_red_pushzone");
-    ::BLU_PUSHZONE <- MM_GetEntByName("plr_blu_pushzone");
+    PLR_TEAMS[2].pushzone = MM_GetEntByName("plr_red_pushzone");
+    PLR_TEAMS[3].pushzone = MM_GetEntByName("plr_blu_pushzone");
 
-    ::RED_TRAIN <- MM_GetEntByName("plr_red_train");
-    ::BLU_TRAIN <- MM_GetEntByName("plr_blu_train");
+    PLR_TEAMS[2].train = MM_GetEntByName("plr_red_train");
+    PLR_TEAMS[3].train = MM_GetEntByName("plr_blu_train");
 
-    ::RED_WATCHER <- MM_GetEntByName("plr_red_watcherA");
-    ::BLU_WATCHER <- MM_GetEntByName("plr_blu_watcherA");
+    PLR_TEAMS[2].watcher = MM_GetEntByName("plr_red_watcherA");
+    PLR_TEAMS[3].watcher = MM_GetEntByName("plr_blu_watcherA");
 
     MM_GetEntByName("plr_red_overtime").Kill();
     MM_GetEntByName("plr_blu_overtime").Kill();
     MM_GetEntByName("plr_overtime_template").Kill();
 
-    ::RED_LOGICCASE <- CreateLogicCase("red_train_case", "Red");
-    ::BLU_LOGICCASE <- CreateLogicCase("blue_train_case", "Blu");
+    PLR_TEAMS[2].logiccase = PLR_CreateLogicCase(2, "red_train_case");
+    PLR_TEAMS[3].logiccase = PLR_CreateLogicCase(3, "blue_train_case");
 
-    EntityOutputs.AddOutput(RED_PUSHZONE, "OnNumCappersChanged2", "red_train_case", "InValue", "", 0, -1);
-    EntityOutputs.AddOutput(BLU_PUSHZONE, "OnNumCappersChanged2", "blue_train_case", "InValue", "", 0, -1);
+    EntityOutputs.AddOutput(PLR_TEAMS[2].pushzone, "OnNumCappersChanged2", "red_train_case", "InValue", "", 0, -1);
+    EntityOutputs.AddOutput(PLR_TEAMS[3].pushzone, "OnNumCappersChanged2", "blue_train_case", "InValue", "", 0, -1);
 
     // Rollback logic replacement
 
-    // MM_GetEntByName("plr_red_rollback").Kill();
-    // MM_GetEntByName("plr_blu_rollback").Kill();
+    PLR_AddRollbackZone(2, "plr_red_pathA_hillA2", "plr_red_pathA_hillA4", "plr_red_pathA_hillA1");
+    PLR_AddRollbackZone(3, "plr_blu_pathA_hillA2", "plr_blu_pathA_hillA4", "plr_blu_pathA_hillA1");
 
-    AddRollbackZone("plr_red_pathA_hillA2", "plr_red_pathA_hillA4", "plr_red_pathA_hillA1", "Red");
-    AddRollbackZone("plr_blu_pathA_hillA2", "plr_blu_pathA_hillA4", "plr_blu_pathA_hillA1", "Blu");
+    PLR_AddRollbackZone(2, "plr_red_pathB_hillA2", "plr_red_pathB_hillA5", "plr_red_pathB_hillA1");
+    PLR_AddRollbackZone(2, "plr_red_pathB_hillB2", "plr_red_pathB_hillB4", "plr_red_pathB_hillB1");
+    PLR_AddRollbackZone(3, "plr_blu_pathB_hillA2", "plr_blu_pathB_hillA5", "plr_blu_pathB_hillA1");
+    PLR_AddRollbackZone(3, "plr_blu_pathB_hillB2", "plr_blu_pathB_hillB4", "plr_blu_pathB_hillB1");
 
-    AddRollbackZone("plr_red_pathB_hillA2", "plr_red_pathB_hillA5", "plr_red_pathB_hillA1", "Red");
-    AddRollbackZone("plr_red_pathB_hillB2", "plr_red_pathB_hillB4", "plr_red_pathB_hillB1", "Red");
-    AddRollbackZone("plr_blu_pathB_hillA2", "plr_blu_pathB_hillA5", "plr_blu_pathB_hillA1", "Blu");
-    AddRollbackZone("plr_blu_pathB_hillB2", "plr_blu_pathB_hillB4", "plr_blu_pathB_hillB1", "Blu");
-
-    AddRollbackZone("plr_red_pathC_hillA2", "plr_red_pathC_hillA6", "plr_red_pathC_hillA1", "Red");
-    AddRollbackZone("plr_red_pathC_hillB2", "plr_red_pathC_hillB6", "plr_red_pathC_hillB1", "Red");
-    AddRollbackZone("plr_blu_pathC_hillA2", "plr_blu_pathC_hillA6", "plr_blu_pathC_hillA1", "Blu");
-    AddRollbackZone("plr_blu_pathC_hillB2", "plr_blu_pathC_hillB6", "plr_blu_pathC_hillB1", "Blu")
+    PLR_AddRollbackZone(2, "plr_red_pathC_hillA2", "plr_red_pathC_hillA6", "plr_red_pathC_hillA1");
+    PLR_AddRollbackZone(2, "plr_red_pathC_hillB2", "plr_red_pathC_hillB6", "plr_red_pathC_hillB1");
+    PLR_AddRollbackZone(3, "plr_blu_pathC_hillA2", "plr_blu_pathC_hillA6", "plr_blu_pathC_hillA1");
+    PLR_AddRollbackZone(3, "plr_blu_pathC_hillB2", "plr_blu_pathC_hillB6", "plr_blu_pathC_hillB1");
 
     // Crossing logic replacement (yes they used "crossover2" twice)
     foreach(entName in [
@@ -73,9 +70,18 @@ function OnGameEvent_teamplay_round_start(params) {
         MM_GetEntByName(entName).Kill();
     }
 
-    AddCrossing("plr_red_pathA15", "plr_red_pathA16", "plr_blu_pathA15", "plr_blu_pathA16", 1);
-    AddCrossing("plr_red_pathB_crossover2_start", "plr_red_pathB_crossover2_end", "plr_blu_pathB_crossover2_start", "plr_blu_pathB_crossover2_end", 2);
-    AddCrossing("plr_red_crossover3_start", "plr_red_pathC_29", "plr_blu_crossover3_start", "plr_blu_pathC_29", 3);
+    AddCrossing([
+        ["plr_red_pathA15", "plr_red_pathA16", 2],
+        ["plr_blu_pathA15", "plr_blu_pathA16", 3]
+    ]);
+    AddCrossing([
+        ["plr_red_pathB_crossover2_start", "plr_red_pathB_crossover2_end", 2],
+        ["plr_blu_pathB_crossover2_start", "plr_blu_pathB_crossover2_end", 3]
+    ]);
+    AddCrossing([
+        ["plr_red_crossover3_start", "plr_red_pathC_29", 2],
+        ["plr_blu_crossover3_start", "plr_blu_pathC_29", 3]
+    ]);
 
     // Fix invisible walls on stage 3 by putting a prop there
     // Flag removal needed to stop sentries trying to shoot through the thin prop (thanks ficool2!)
@@ -144,12 +150,12 @@ function OnGameEvent_teamplay_round_start(params) {
     NetProps.SetPropBool(MM_GetEntByName("plr_red_watcherC"), "m_bHandleTrainMovement", false);
     NetProps.SetPropBool(MM_GetEntByName("plr_blu_watcherC"), "m_bHandleTrainMovement", false);
 
-    EntityOutputs.AddOutput(RED_PUSHZONE, "OnNumCappersChanged2", "plr_red_watcherA", "SetNumTrainCappers", "", 0, -1);
-    EntityOutputs.AddOutput(BLU_PUSHZONE, "OnNumCappersChanged2", "plr_blu_watcherA", "SetNumTrainCappers", "", 0, -1);
-    EntityOutputs.AddOutput(RED_PUSHZONE, "OnNumCappersChanged2", "plr_red_watcherB", "SetNumTrainCappers", "", 0, -1);
-    EntityOutputs.AddOutput(BLU_PUSHZONE, "OnNumCappersChanged2", "plr_blu_watcherB", "SetNumTrainCappers", "", 0, -1);
-    EntityOutputs.AddOutput(RED_PUSHZONE, "OnNumCappersChanged2", "plr_red_watcherC", "SetNumTrainCappers", "", 0, -1);
-    EntityOutputs.AddOutput(BLU_PUSHZONE, "OnNumCappersChanged2", "plr_blu_watcherC", "SetNumTrainCappers", "", 0, -1);
+    EntityOutputs.AddOutput(PLR_TEAMS[2].pushzone, "OnNumCappersChanged2", "plr_red_watcherA", "SetNumTrainCappers", "", 0, -1);
+    EntityOutputs.AddOutput(PLR_TEAMS[3].pushzone, "OnNumCappersChanged2", "plr_blu_watcherA", "SetNumTrainCappers", "", 0, -1);
+    EntityOutputs.AddOutput(PLR_TEAMS[2].pushzone, "OnNumCappersChanged2", "plr_red_watcherB", "SetNumTrainCappers", "", 0, -1);
+    EntityOutputs.AddOutput(PLR_TEAMS[3].pushzone, "OnNumCappersChanged2", "plr_blu_watcherB", "SetNumTrainCappers", "", 0, -1);
+    EntityOutputs.AddOutput(PLR_TEAMS[2].pushzone, "OnNumCappersChanged2", "plr_red_watcherC", "SetNumTrainCappers", "", 0, -1);
+    EntityOutputs.AddOutput(PLR_TEAMS[3].pushzone, "OnNumCappersChanged2", "plr_blu_watcherC", "SetNumTrainCappers", "", 0, -1);
 
     // Prevent both win outputs being fired for cart warps.
 
@@ -168,8 +174,8 @@ function OnGameEvent_teamplay_round_start(params) {
     EntityOutputs.AddOutput(MM_GetEntByName("plr_round_C"), "OnStart", "!self", "RunScriptCode", "OnRound3Start()", 0, -1);
 
     // Add thinks to carts
-    CreateCartAutoUpdater(RED_TRAIN, 2);
-    CreateCartAutoUpdater(BLU_TRAIN, 3);
+    PLR_CreateCartAutoUpdater(2, PLR_TEAMS[2].train);
+    PLR_CreateCartAutoUpdater(3, PLR_TEAMS[3].train);
 }
 
 function OnRound2Start() {
@@ -179,8 +185,8 @@ function OnRound2Start() {
     ::PLR_TIMER_NAME <- "plr_timer_b";
     ::PLR_TIMER = MM_GetEntByName(PLR_TIMER_NAME);
 
-    ::RED_WATCHER <- MM_GetEntByName("plr_red_watcherB");
-    ::BLU_WATCHER <- MM_GetEntByName("plr_blu_watcherB");
+    PLR_TEAMS[2].watcher = MM_GetEntByName("plr_red_watcherB");
+    PLR_TEAMS[3].watcher = MM_GetEntByName("plr_blu_watcherB");
 
     EntityOutputs.AddOutput(PLR_TIMER, "OnSetupFinished", "!self", "SetTime", GetRoundTimeString(45), 0, -1);
     EntFireByHandle(PLR_TIMER, "ShowInHud", "1", 0, null, null);
@@ -188,11 +194,11 @@ function OnRound2Start() {
 
     // Handle cart warp
     if(ROUND_WIN_COUNTER == 2) {
-        RED_TRAIN.AcceptInput("TeleportToPathTrack", "plr_red_pathB_start1", null, null);
-        BLU_TRAIN.AcceptInput("TeleportToPathTrack", "plr_blu_pathB_start0", null, null);
+        PLR_TEAMS[2].train.AcceptInput("TeleportToPathTrack", "plr_red_pathB_start1", null, null);
+        PLR_TEAMS[3].train.AcceptInput("TeleportToPathTrack", "plr_blu_pathB_start0", null, null);
     } else if (ROUND_WIN_COUNTER == 3) {
-        RED_TRAIN.AcceptInput("TeleportToPathTrack", "plr_red_pathB_start0", null, null);
-        BLU_TRAIN.AcceptInput("TeleportToPathTrack", "plr_blu_pathB_start1", null, null);
+        PLR_TEAMS[2].train.AcceptInput("TeleportToPathTrack", "plr_red_pathB_start0", null, null);
+        PLR_TEAMS[3].train.AcceptInput("TeleportToPathTrack", "plr_blu_pathB_start1", null, null);
     }
 
     ResetCartStates();
@@ -205,8 +211,8 @@ function OnRound3Start() {
     ::PLR_TIMER_NAME <- "plr_timer_c";
     ::PLR_TIMER = MM_GetEntByName(PLR_TIMER_NAME);
 
-    ::RED_WATCHER <- MM_GetEntByName("plr_red_watcherC");
-    ::BLU_WATCHER <- MM_GetEntByName("plr_blu_watcherC");
+    PLR_TEAMS[2].watcher = MM_GetEntByName("plr_red_watcherC");
+    PLR_TEAMS[3].watcher = MM_GetEntByName("plr_blu_watcherC");
 
     EntityOutputs.AddOutput(PLR_TIMER, "OnSetupFinished", "!self", "SetTime", GetRoundTimeString(), 0, -1);
     EntFireByHandle(PLR_TIMER, "ShowInHud", "1", 0, null, null);
@@ -218,16 +224,16 @@ function OnRound3Start() {
     ResetCartStates();
 }
 
-::WinRedBase <- WinRed;
-::WinBluBase <- WinBlu;
+::WinRed_Base <- WinRed;
+::WinBlu_Base <- WinBlu;
 
 function WinRed() {
-    WinRed();
+    WinRed_Base();
     ::ROUND_WIN_COUNTER <- ROUND_WIN_COUNTER + 2;
 }
 
 function WinBlu() {
-    WinBluBase();
+    WinBlu_Base();
     ::ROUND_WIN_COUNTER <- ROUND_WIN_COUNTER + 3;
 }
 

--- a/mega_mod/mapmods/plr_pipeline.nut
+++ b/mega_mod/mapmods/plr_pipeline.nut
@@ -71,19 +71,19 @@ function OnGameEvent_teamplay_round_start(params) {
         MM_GetEntByName(entName).Kill();
     }
 
-    AddCrossing([
+    PLR_AddCrossing([
         ["red_path_9", "red_path_12", 2],
         ["blue_path_9", "blue_path_12", 3]
     ]);
-    AddCrossing([
+    PLR_AddCrossing([
         ["red_path_b_8", "red_path_b_11", 2],
         ["blue_path_b_8", "blue_path_b_11", 3]
     ]);
 
     // Timer logic replacement
     EntityOutputs.RemoveOutput(PLR_TIMER, "OnSetupFinished", "setup_timer_a", "Disable", "");
-    EntityOutputs.AddOutput(PLR_TIMER, "OnSetupFinished", "!self", "SetTime", GetRoundTimeString(65), 0, -1);
-    EntityOutputs.AddOutput(PLR_TIMER, "OnFinished", "!self", "RunScriptCode", "StartOvertime()", 0, -1);
+    EntityOutputs.AddOutput(PLR_TIMER, "OnSetupFinished", "!self", "SetTime", PLR_GetRoundTimeString(65), 0, -1);
+    EntityOutputs.AddOutput(PLR_TIMER, "OnFinished", "!self", "RunScriptCode", "PLR_StartOvertime()", 0, -1);
 
     SpawnEntityFromTable("team_round_timer", {
         setup_length = 6,
@@ -92,7 +92,7 @@ function OnGameEvent_teamplay_round_start(params) {
         timer_length = 600,
         StartDisabled = 1,
         show_in_hud = 0,
-        "OnFinished#1": "!self,RunScriptCode,StartOvertime(),0,1",
+        "OnFinished#1": "!self,RunScriptCode,PLR_StartOvertime(),0,1",
     });
 
     // Multi-stage logic
@@ -132,10 +132,10 @@ function OnRound2Start() {
     PLR_TEAMS[3].watcher = MM_GetEntByName("blue_watcher_2");
 
     EntityOutputs.RemoveOutput(PLR_TIMER, "OnSetupFinished", "setup_timer_b", "Disable", "");
-    EntityOutputs.AddOutput(PLR_TIMER, "OnSetupFinished", "!self", "SetTime", GetRoundTimeString(65), 0, -1);
-    EntityOutputs.AddOutput(PLR_TIMER, "OnFinished", "!self", "RunScriptCode", "StartOvertime()", 0, -1);
+    EntityOutputs.AddOutput(PLR_TIMER, "OnSetupFinished", "!self", "SetTime", PLR_GetRoundTimeString(65), 0, -1);
+    EntityOutputs.AddOutput(PLR_TIMER, "OnFinished", "!self", "RunScriptCode", "PLR_StartOvertime()", 0, -1);
 
-    ResetCartStates();
+    PLR_ResetCartStates();
 }
 
 function OnRound3Start() {
@@ -143,7 +143,7 @@ function OnRound3Start() {
 
     ::PLR_TIMER_NAME <- "setup_timer_c";
     ::PLR_TIMER = MM_GetEntByName(PLR_TIMER_NAME);
-    EntityOutputs.AddOutput(PLR_TIMER, "OnSetupFinished", "!self", "SetTime", GetRoundTimeString(), 0, -1);
+    EntityOutputs.AddOutput(PLR_TIMER, "OnSetupFinished", "!self", "SetTime", PLR_GetRoundTimeString(), 0, -1);
 
     PLR_TEAMS[2].watcher = MM_GetEntByName("red_watcher_3");
     PLR_TEAMS[3].watcher = MM_GetEntByName("blue_watcher_3");
@@ -151,7 +151,7 @@ function OnRound3Start() {
     EntFireByHandle(PLR_TIMER, "ShowInHud", "1", 0, null, null);
     EntFireByHandle(PLR_TIMER, "Enable", "", 0.1, null, null);
 
-    ResetCartStates();
+    PLR_ResetCartStates();
 }
 
 __CollectGameEventCallbacks(this);

--- a/mega_mod/mapmods/plr_pipeline.nut
+++ b/mega_mod/mapmods/plr_pipeline.nut
@@ -3,38 +3,38 @@ IncludeScript("mega_mod/common/plr_overtime.nut");
 
 function OnGameEvent_teamplay_round_start(params) {
 
-    if(params.full_reset != 1) return;
+    if (params.full_reset != 1) return;
 
     InitGlobalVars();
 
     ::PLR_TIMER_NAME <- "setup_timer_a";
     ::PLR_TIMER = MM_GetEntByName(PLR_TIMER_NAME);
 
-    ::RED_CARTSPARKS_ARRAY <- [MM_GetEntByName("red_cart_spark_left"), MM_GetEntByName("red_cart_spark_right")];
-    ::BLU_CARTSPARKS_ARRAY <- [MM_GetEntByName("blue_cart_spark_left"), MM_GetEntByName("blue_cart_spark_right")];
+    PLR_TEAMS[2].cartsparks = [MM_GetEntByName("red_cart_spark_left"), MM_GetEntByName("red_cart_spark_right")];
+    PLR_TEAMS[3].cartsparks = [MM_GetEntByName("blue_cart_spark_left"), MM_GetEntByName("blue_cart_spark_right")];
 
-    ::RED_FLASHINGLIGHT <- MM_GetEntByName("red_cart_particles");
-    ::BLU_FLASHINGLIGHT <- MM_GetEntByName("blue_cart_particles");
+    PLR_TEAMS[2].flashinglight = MM_GetEntByName("red_cart_particles");
+    PLR_TEAMS[3].flashinglight = MM_GetEntByName("blue_cart_particles");
 
-    ::RED_PUSHZONE <- MM_GetEntByName("red_cap_area");
-    ::BLU_PUSHZONE <- MM_GetEntByName("blue_cap_area");
+    PLR_TEAMS[2].pushzone = MM_GetEntByName("red_cap_area");
+    PLR_TEAMS[3].pushzone = MM_GetEntByName("blue_cap_area");
 
-    ::RED_TRAIN <- MM_GetEntByName("red_cart_tracktrain");
-    ::BLU_TRAIN <- MM_GetEntByName("blue_cart_tracktrain");
+    PLR_TEAMS[2].train = MM_GetEntByName("red_cart_tracktrain");
+    PLR_TEAMS[3].train = MM_GetEntByName("blue_cart_tracktrain");
 
-    ::RED_WATCHER <- MM_GetEntByName("red_watcher_1");
-    ::BLU_WATCHER <- MM_GetEntByName("blue_watcher_1");
+    PLR_TEAMS[2].watcher = MM_GetEntByName("red_watcher_1");
+    PLR_TEAMS[3].watcher = MM_GetEntByName("blue_watcher_1");
 
     MM_GetEntByName("red_train_case").Kill();
     MM_GetEntByName("blue_train_case").Kill();
     MM_GetEntByName("red_train_remap").Kill();
     MM_GetEntByName("blue_train_remap").Kill();
 
-    ::RED_LOGICCASE <- CreateLogicCase("red_train_case", "Red");
-    ::BLU_LOGICCASE <- CreateLogicCase("blue_train_case", "Blu");
+    PLR_TEAMS[2].logiccase = PLR_CreateLogicCase(2, "red_train_case");
+    PLR_TEAMS[3].logiccase = PLR_CreateLogicCase(3, "blue_train_case");
 
-    EntityOutputs.AddOutput(RED_PUSHZONE, "OnNumCappersChanged2", "red_train_case", "InValue", "", 0, -1);
-    EntityOutputs.AddOutput(BLU_PUSHZONE, "OnNumCappersChanged2", "blue_train_case", "InValue", "", 0, -1);
+    EntityOutputs.AddOutput(PLR_TEAMS[2].pushzone, "OnNumCappersChanged2", "red_train_case", "InValue", "", 0, -1);
+    EntityOutputs.AddOutput(PLR_TEAMS[3].pushzone, "OnNumCappersChanged2", "blue_train_case", "InValue", "", 0, -1);
 
     // Rollback logic replacement
     MM_GetEntByName("red_train_hill_branch").Kill();
@@ -42,19 +42,19 @@ function OnGameEvent_teamplay_round_start(params) {
     MM_GetEntByName("blue_train_hill_branch").Kill();
     MM_GetEntByName("blue_train_hillclimb_backstop_relay").Kill();
 
-    AddRollbackZone("red_path_26", "red_path_27", "red_path_25", "Red");
-    AddRollbackZone("blue_path_26", "blue_path_27", "blue_path_25", "Blu");
+    PLR_AddRollbackZone(2, "red_path_26", "red_path_27", "red_path_25");
+    PLR_AddRollbackZone(3, "blue_path_26", "blue_path_27", "blue_path_25");
 
-    AddRollbackZone("red_path_b_22", "red_path_b_23", "red_path_b_21", "Red");
-    AddRollbackZone("blue_path_b_22", "blue_path_b_23", "blue_path_b_21", "Blu");
+    PLR_AddRollbackZone(2, "red_path_b_22", "red_path_b_23", "red_path_b_21");
+    PLR_AddRollbackZone(3, "blue_path_b_22", "blue_path_b_23", "blue_path_b_21");
 
-    AddRollbackZone("red_path_c_3", "red_path_c_6", "red_path_c_2", "Red");
-    AddRollbackZone("red_path_c_8", "red_path_c_11", "red_path_c_7", "Red");
-    AddRollbackZone("blue_path_c_3", "blue_path_c_6", "blue_path_c_2", "Blu");
-    AddRollbackZone("blue_path_c_8", "blue_path_c_11", "blue_path_c_7", "Blu");
+    PLR_AddRollbackZone(2, "red_path_c_3", "red_path_c_6", "red_path_c_2");
+    PLR_AddRollbackZone(2, "red_path_c_8", "red_path_c_11", "red_path_c_7");
+    PLR_AddRollbackZone(3, "blue_path_c_3", "blue_path_c_6", "blue_path_c_2");
+    PLR_AddRollbackZone(3, "blue_path_c_8", "blue_path_c_11", "blue_path_c_7");
 
     // Crossing logic replacement
-    foreach(entName in [
+    foreach (entName in [
         "blue_crossover_b_relay",
         "blue_crossover_b_relay2",
         "blue_crossover_b_stop_relay",
@@ -71,8 +71,14 @@ function OnGameEvent_teamplay_round_start(params) {
         MM_GetEntByName(entName).Kill();
     }
 
-    AddCrossing("red_path_9", "red_path_12", "blue_path_9", "blue_path_12", 1);
-    AddCrossing("red_path_b_8", "red_path_b_11", "blue_path_b_8", "blue_path_b_11", 2);
+    AddCrossing([
+        ["red_path_9", "red_path_12", 2],
+        ["blue_path_9", "blue_path_12", 3]
+    ]);
+    AddCrossing([
+        ["red_path_b_8", "red_path_b_11", 2],
+        ["blue_path_b_8", "blue_path_b_11", 3]
+    ]);
 
     // Timer logic replacement
     EntityOutputs.RemoveOutput(PLR_TIMER, "OnSetupFinished", "setup_timer_a", "Disable", "");
@@ -86,7 +92,7 @@ function OnGameEvent_teamplay_round_start(params) {
         timer_length = 600,
         StartDisabled = 1,
         show_in_hud = 0,
-        "OnFinished#1" : "!self,RunScriptCode,StartOvertime(),0,1",
+        "OnFinished#1": "!self,RunScriptCode,StartOvertime(),0,1",
     });
 
     // Multi-stage logic
@@ -94,8 +100,8 @@ function OnGameEvent_teamplay_round_start(params) {
     EntityOutputs.AddOutput(MM_GetEntByName("round3"), "OnStart", "!self", "RunScriptCode", "OnRound3Start()", 0, -1);
 
     // Add thinks to carts
-    CreateCartAutoUpdater(RED_TRAIN, 2);
-    CreateCartAutoUpdater(BLU_TRAIN, 3);
+    PLR_CreateCartAutoUpdater(2, PLR_TEAMS[2].train);
+    PLR_CreateCartAutoUpdater(3, PLR_TEAMS[3].train);
 }
 
 ::WinBase <- OnGameEvent_teamplay_round_win;
@@ -103,14 +109,13 @@ function OnGameEvent_teamplay_round_start(params) {
 // Pipeline has an end-of-round win sequence that requires the winning cart to keep moving forward.
 function OnGameEvent_teamplay_round_win(params) {
     if (params.full_round == 1 && params.team != 0) {
-        ::BLOCK_RED <- true;
-        ::BLOCK_BLU <- true;
+        PLR_ForEachTeam(function(team, state) { state.blocked = true; });
         if (params.team == 2) {
-            StopBlu();
-            AdvanceRed(3, false);
+            PLR_Stop(3);
+            PLR_Advance(2, 3, false);
         } else if (params.team == 3) {
-            StopRed();
-            AdvanceBlu(3, false);
+            PLR_Stop(2);
+            PLR_Advance(3, 3, false);
         }
         return;
     }
@@ -118,14 +123,13 @@ function OnGameEvent_teamplay_round_win(params) {
 }
 
 function OnRound2Start() {
-
-    if(PLR_TIMER && PLR_TIMER.IsValid()) PLR_TIMER.Kill();
+    if (PLR_TIMER && PLR_TIMER.IsValid()) PLR_TIMER.Kill();
 
     ::PLR_TIMER_NAME <- "setup_timer_b";
     ::PLR_TIMER = MM_GetEntByName(PLR_TIMER_NAME);
 
-    ::RED_WATCHER <- MM_GetEntByName("red_watcher_2");
-    ::BLU_WATCHER <- MM_GetEntByName("blue_watcher_2");
+    PLR_TEAMS[2].watcher = MM_GetEntByName("red_watcher_2");
+    PLR_TEAMS[3].watcher = MM_GetEntByName("blue_watcher_2");
 
     EntityOutputs.RemoveOutput(PLR_TIMER, "OnSetupFinished", "setup_timer_b", "Disable", "");
     EntityOutputs.AddOutput(PLR_TIMER, "OnSetupFinished", "!self", "SetTime", GetRoundTimeString(65), 0, -1);
@@ -135,15 +139,14 @@ function OnRound2Start() {
 }
 
 function OnRound3Start() {
-
-    if(PLR_TIMER && PLR_TIMER.IsValid()) PLR_TIMER.Kill();
+    if (PLR_TIMER && PLR_TIMER.IsValid()) PLR_TIMER.Kill();
 
     ::PLR_TIMER_NAME <- "setup_timer_c";
     ::PLR_TIMER = MM_GetEntByName(PLR_TIMER_NAME);
     EntityOutputs.AddOutput(PLR_TIMER, "OnSetupFinished", "!self", "SetTime", GetRoundTimeString(), 0, -1);
 
-    ::RED_WATCHER <- MM_GetEntByName("red_watcher_3");
-    ::BLU_WATCHER <- MM_GetEntByName("blue_watcher_3");
+    PLR_TEAMS[2].watcher = MM_GetEntByName("red_watcher_3");
+    PLR_TEAMS[3].watcher = MM_GetEntByName("blue_watcher_3");
 
     EntFireByHandle(PLR_TIMER, "ShowInHud", "1", 0, null, null);
     EntFireByHandle(PLR_TIMER, "Enable", "", 0.1, null, null);


### PR DESCRIPTION
Goals were basically take code like this:
```
function BlockRedCart(blocked) {
    ::BLOCK_RED <- blocked;
    UpdateRedCart(CASE_RED);
    UpdateBluCart(CASE_BLU);
}

function BlockBluCart(blocked) {
    ::BLOCK_BLU <- blocked;
    UpdateBluCart(CASE_BLU);
    UpdateRedCart(CASE_RED);
}
```
...and turn it into this:
```
function PLR_BlockCart(team, blocked) {
    PLR_TEAMS[team].blocked = blocked;
    PLR_ForEachTeam(function(other, state) {
        if (other != team) PLR_UpdateCart(other, state.pushstate);
    });
    PLR_UpdateCart(team, PLR_TEAMS[team].pushstate);
}
```

Huge amounts of tokenmaxxing went into this but as the fundamental logic was already there (two copies in fact), LLMs did a surprisingly good job at cleaning it up. Matterhorn's custom logic was almost completely one-shot by this.

Additional goals:
- Lay the groundwork for potential 4plr implementations (looking at you Sisyphus).
- Make the code generally easier to work with.
- Improve the base mod's ability to handle custom data.